### PR TITLE
style: BusinessCardContainer 공통 컴포넌트 (재PR)

### DIFF
--- a/src/components/common/BusinessCardContainer/index.tsx
+++ b/src/components/common/BusinessCardContainer/index.tsx
@@ -1,0 +1,112 @@
+import styled from '@emotion/styled'
+import { useState } from 'react'
+import { TiDelete } from 'react-icons/ti'
+
+import camera from '@/assets/images/camera.svg'
+import { palette } from '@/styles/palette'
+
+import Spacing from '../Spacing'
+import { Text } from '../Text'
+
+type BusinessCardContainerProps = {
+  isDarkMode: boolean
+}
+
+const BusinessCardContainer = ({ isDarkMode }: BusinessCardContainerProps) => {
+  const [uploadedImage, setUploadedImage] = useState<string | null>(null)
+
+  const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!uploadedImage) {
+      const file = event.target.files?.[0]
+      const reader = new FileReader()
+
+      reader.onloadend = () => {
+        setUploadedImage(reader.result as string)
+      }
+
+      if (file) {
+        reader.readAsDataURL(file)
+      }
+    }
+  }
+
+  const handleRemoveImage = () => {
+    setUploadedImage(null)
+  }
+
+  return (
+    <Wrapper>
+      <Text
+        font={'Body_20'}
+        fontWeight={700}
+        letterSpacing={-1}
+        textColor={isDarkMode ? palette.WHITE : palette.BLACK}
+      >
+        {'명함사진 업로드'}
+      </Text>
+      <Spacing size={10} />
+      <ImageContainer>
+        {uploadedImage ? (
+          <>
+            <StyledImage src={uploadedImage} alt={'Uploaded'} />
+            <TiDelete
+              style={{
+                position: 'absolute',
+                top: -10,
+                right: -15,
+                width: 24,
+                height: 24,
+                cursor: 'pointer',
+                color: isDarkMode ? palette.GRAY300 : palette.BLACK,
+              }}
+              onClick={handleRemoveImage}
+            />
+          </>
+        ) : (
+          <label style={{ cursor: 'pointer' }}>
+            <input type={'file'} onChange={handleImageUpload} style={{ display: 'none' }} />
+            <Placeholder>
+              <CameraIcon src={camera} alt={'Upload Placeholder'} />
+            </Placeholder>
+          </label>
+        )}
+      </ImageContainer>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div`
+  position: relative;
+  width: 300px;
+`
+
+const Placeholder = styled.div`
+  width: 88px;
+  height: 88px;
+  background-color: ${palette.WHITE};
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+`
+
+const ImageContainer = styled.div`
+  width: 88px;
+  position: relative;
+`
+
+const StyledImage = styled.img`
+  width: 88px;
+  height: 88px;
+  object-fit: cover;
+  position: relative;
+  border-radius: 10px;
+`
+
+const CameraIcon = styled.img`
+  width: 38px;
+  height: 38px;
+`
+
+export default BusinessCardContainer

--- a/src/components/common/Text/index.tsx
+++ b/src/components/common/Text/index.tsx
@@ -15,11 +15,13 @@ export const Text = styled.div<{
   font: KeyOfTypo
   fontWeight: number
   letterSpacing: number
+  textColor?: string
 }>`
-  ${({ font, fontWeight, letterSpacing }) => {
+  ${({ font, fontWeight, letterSpacing, textColor }) => {
     const fontFunc = typo[font]
     return css`
       ${fontFunc(fontWeight, letterSpacing)}
+      color: ${textColor};
     `
   }}
 `


### PR DESCRIPTION
## 이슈번호
<!-- - close 뒤에 이슈 달아주기 -->

## 작업 내용 설명
<!-- 스크린샷 및 작업내용을 적어주세요 -->
![image](https://github.com/coffee-meet/frontend/assets/124763142/7f24854e-1ded-4f93-a370-adccb567a4c3)
![image](https://github.com/coffee-meet/frontend/assets/124763142/1f13e764-c958-4246-b7cb-ef3f2372a0e0)

```tsx
<BusinessCardContainer isDarkMode={false} />
<BusinessCardContainer isDarkMode={true} />
`

isDarkMode prop을 통해, '명함사진업로드' 텍스트 색과 deleteButton 색 변경 가능

## 리뷰어에게 한마디
<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->
Text 색을 변경하는 경우를 고려하여, common 폴더의 Text 공통 컴포넌트 prop값으로 'textColor' 추가 
(Text 공통 컴포넌트 추가사항)
