### PR TITLE
refactor: Input 컴포넌트 ref, onchange 추가

### DIFF
--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import React, { ForwardedRef } from 'react'
 
 type InputProps = {
   placeholder?: string
@@ -12,25 +13,32 @@ type InputProps = {
   inputTextSize?: string
   inputBackgroundColor?: string
   borderRadius?: string
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
 }
 
-const Input = ({
-  placeholder,
-  placeholderSize,
-  placeholderColor,
-  width,
-  height,
-  borderColor,
-  borderWidth,
-  borderRadius,
-  inputTextColor,
-  inputTextSize,
-  inputBackgroundColor,
-}: InputProps) => {
-  return (
-    <>
+const Input = React.forwardRef(
+  (
+    {
+      placeholder,
+      placeholderSize,
+      placeholderColor,
+      width,
+      height,
+      borderColor,
+      borderWidth,
+      borderRadius,
+      inputTextColor,
+      inputTextSize,
+      inputBackgroundColor,
+      onChange,
+    }: InputProps,
+    ref: ForwardedRef<HTMLInputElement>,
+  ) => {
+    return (
       <InputWrapper>
         <StyleInput
+          ref={ref}
+          onChange={onChange}
           placeholder={placeholder}
           placeholderSize={placeholderSize}
           placeholderColor={placeholderColor}
@@ -42,11 +50,12 @@ const Input = ({
           inputTextSize={inputTextSize}
           inputBackgroundColor={inputBackgroundColor}
           borderRadius={borderRadius}
-        ></StyleInput>
+        />
       </InputWrapper>
-    </>
-  )
-}
+    )
+  },
+)
+Input.displayName = 'Input'
 
 const InputWrapper = styled.div`
   position: relative;
@@ -57,8 +66,6 @@ const StyleInput = styled.input<InputProps>`
     font-size: ${(props) => props.placeholderSize};
     color: ${(props) => props.placeholderColor};
   }
-  position: relative;
-  placeholder: ${(props) => props.placeholder};
   width: ${(props) => props.width};
   height: ${(props) => props.height};
   border-color: ${(props) => props.borderColor};
@@ -67,6 +74,7 @@ const StyleInput = styled.input<InputProps>`
   background-color: ${(props) => props.inputBackgroundColor};
   border-radius: ${(props) => props.borderRadius};
   font-size: ${(props) => props.inputTextSize};
+  position: relative; // This should be adjusted if needed.
 `
 
 export default Input

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -35,8 +35,8 @@ const Input = React.forwardRef(
     ref: ForwardedRef<HTMLInputElement>,
   ) => {
     return (
-      <InputWrapper>
-        <StyleInput
+      <StyledInputWrapper>
+        <StyledInput
           ref={ref}
           onChange={onChange}
           placeholder={placeholder}
@@ -51,17 +51,17 @@ const Input = React.forwardRef(
           inputBackgroundColor={inputBackgroundColor}
           borderRadius={borderRadius}
         />
-      </InputWrapper>
+      </StyledInputWrapper>
     )
   },
 )
 Input.displayName = 'Input'
 
-const InputWrapper = styled.div`
+const StyledInputWrapper = styled.div`
   position: relative;
 `
 
-const StyleInput = styled.input<InputProps>`
+const StyledInput = styled.input<InputProps>`
   ::placeholder {
     font-size: ${(props) => props.placeholderSize};
     color: ${(props) => props.placeholderColor};
@@ -74,7 +74,7 @@ const StyleInput = styled.input<InputProps>`
   background-color: ${(props) => props.inputBackgroundColor};
   border-radius: ${(props) => props.borderRadius};
   font-size: ${(props) => props.inputTextSize};
-  position: relative; // This should be adjusted if needed.
+  position: relative;
 `
 
 export default Input


### PR DESCRIPTION
## 이슈번호
<!-- - close 뒤에 이슈 달아주기 -->
close: #89 

## 작업 내용 설명
<!-- 스크린샷 및 작업내용을 적어주세요 -->
- 상위 컴포넌트에서 Input을 참조할 수 있도록 forwardRef 적용. 
-  onchange 속성을 통해, onchange 이벤트 props 전달.
## 리뷰어에게 한마디
<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->
처음에 react hook form의 controller 속성을 사용하여 input의 리렌더링을 막는 것을 고려하였는데, 기존 방법과 공통 컴포넌트 자체를 react hook form 속성들을 공통컴포넌트에 바로 적용하는 것중 어떤 것이 더 좋을지 고려해보면 좋을 것 같습니다.

아직은 react hook form에 익숙치 않아 공통 컴포넌트에 곧바로 적용하기에는 문제가 생길 수도 있을 것 같아, 우선은 해당 공통 컴포넌트를 사용할 수 있도록 ref 속성과 onchange 속성을 추가하였습니다.