### PR TITLE
feature: 로그인 페이지 OAuth 연결 + 반응형 레이아웃 구성

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import ChattingPage from '@/pages/chatting'
 import HomePage from '@/pages/home'
 import LandingPage from '@/pages/landing'
 import LoginPage from '@/pages/login'
+import LoginPendingPage from '@/pages/loginPending'
 import NotFoundPage from '@/pages/notFound/NotFound'
 import ProfilePage from '@/pages/profile'
 import PrivateRoute from '@/pages/redirect/PrivateRoute'
@@ -25,9 +26,10 @@ const App = () => {
           <Route path={'*'} element={<NotFoundPage />}></Route>
         </Route>
 
-        <Route element={<PrivateRoute auth={false} />}>
+        <Route element={<PrivateRoute auth={true} />}>
           <Route path={'/landing'} element={<LandingPage />} />
           <Route path={'/login'} element={<LoginPage />} />
+          <Route path={'/login-pending-page'} element={<LoginPendingPage />} />
           <Route path={'/register/*'} element={<RegisterPage />} />
           <Route path={'/admin-login'} element={<AdminLoginPage />} />
           <Route path={'*'} element={<NotFoundPage />}></Route>

--- a/src/components/common/Buttons/IconButton/KakaoButton.tsx
+++ b/src/components/common/Buttons/IconButton/KakaoButton.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled'
 
 import KakaoIcon from '@/assets/icons/KakaoIcon'
+import { OAuthButtonProps, StyledIconWrapper } from '@/components/common/Buttons/IconButton'
 import { Text } from '@/components/common/Text'
 import { palette } from '@/styles/palette'
 
-import { StyledIconWrapper } from '.'
-
 export const ButtonWrapper = styled.button<{
   buttonTheme: 'kakao' | 'naver'
+  onClick: () => void
 }>`
   width: 320px;
   height: 60px;
@@ -19,8 +19,8 @@ export const ButtonWrapper = styled.button<{
   box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.15);
 `
 
-const KakaoButton = () => (
-  <ButtonWrapper buttonTheme={'kakao'}>
+const KakaoButton = ({ moveToOAuthProvider }: OAuthButtonProps) => (
+  <ButtonWrapper buttonTheme={'kakao'} onClick={moveToOAuthProvider}>
     <StyledIconWrapper
       style={{
         margin: '4px 38px 4px 20px',

--- a/src/components/common/Buttons/IconButton/KakaoButton.tsx
+++ b/src/components/common/Buttons/IconButton/KakaoButton.tsx
@@ -10,14 +10,14 @@ const KakaoButton = ({ moveToOAuthProvider }: OAuthButtonProps) => (
     <StyledIconWrapper>
       <KakaoIcon width={53} height={53} iconWidth={35} iconHeight={35} borderRadius={10} />
     </StyledIconWrapper>
-    <Text
+    <StyledButtonText
       font={'Body_18'}
       fontWeight={600}
       letterSpacing={-1}
       style={{ flex: 1, textAlign: 'left', marginLeft: 20 }}
     >
       {'카카오톡으로 시작'}
-    </Text>
+    </StyledButtonText>
   </StyledButtonWrapper>
 )
 
@@ -36,6 +36,12 @@ export const StyledButtonWrapper = styled.button<{
 
   @media (max-width: 280px) {
     width: 250px;
+  }
+`
+
+export const StyledButtonText = styled(Text)`
+  @media (max-width: 280px) {
+    font-size: 16px;
   }
 `
 

--- a/src/components/common/Buttons/IconButton/KakaoButton.tsx
+++ b/src/components/common/Buttons/IconButton/KakaoButton.tsx
@@ -5,7 +5,23 @@ import { OAuthButtonProps, StyledIconWrapper } from '@/components/common/Buttons
 import { Text } from '@/components/common/Text'
 import { palette } from '@/styles/palette'
 
-export const ButtonWrapper = styled.button<{
+const KakaoButton = ({ moveToOAuthProvider }: OAuthButtonProps) => (
+  <StyledButtonWrapper buttonTheme={'kakao'} onClick={moveToOAuthProvider}>
+    <StyledIconWrapper>
+      <KakaoIcon width={53} height={53} iconWidth={35} iconHeight={35} borderRadius={10} />
+    </StyledIconWrapper>
+    <Text
+      font={'Body_18'}
+      fontWeight={600}
+      letterSpacing={-1}
+      style={{ flex: 1, textAlign: 'left', marginLeft: 20 }}
+    >
+      {'카카오톡으로 시작'}
+    </Text>
+  </StyledButtonWrapper>
+)
+
+export const StyledButtonWrapper = styled.button<{
   buttonTheme: 'kakao' | 'naver'
   onClick: () => void
 }>`
@@ -17,26 +33,10 @@ export const ButtonWrapper = styled.button<{
   justify-content: space-between;
   align-items: center;
   box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.15);
-`
 
-const KakaoButton = ({ moveToOAuthProvider }: OAuthButtonProps) => (
-  <ButtonWrapper buttonTheme={'kakao'} onClick={moveToOAuthProvider}>
-    <StyledIconWrapper
-      style={{
-        margin: '4px 38px 4px 20px',
-      }}
-    >
-      <KakaoIcon width={53} height={53} iconWidth={35} iconHeight={35} borderRadius={10} />
-    </StyledIconWrapper>
-    <Text
-      font={'Body_18'}
-      fontWeight={600}
-      letterSpacing={-1}
-      style={{ flex: 1, textAlign: 'left', marginLeft: 20 }}
-    >
-      {'카카오톡으로 시작'}
-    </Text>
-  </ButtonWrapper>
-)
+  @media (max-width: 280px) {
+    width: 250px;
+  }
+`
 
 export default KakaoButton

--- a/src/components/common/Buttons/IconButton/NaverButton.tsx
+++ b/src/components/common/Buttons/IconButton/NaverButton.tsx
@@ -1,13 +1,11 @@
 import NaverIcon from '@/assets/icons/NaverIcon'
+import { OAuthButtonProps, StyledIconWrapper } from '@/components/common/Buttons/IconButton'
+import { ButtonWrapper } from '@/components/common/Buttons/IconButton/KakaoButton'
 import { Text } from '@/components/common/Text'
 import { palette } from '@/styles/palette'
-
-import { StyledIconWrapper } from '.'
-import { ButtonWrapper } from './KakaoButton'
-
-const NaverButton = () => {
+const NaverButton = ({ moveToOAuthProvider }: OAuthButtonProps) => {
   return (
-    <ButtonWrapper buttonTheme={'naver'}>
+    <ButtonWrapper buttonTheme={'naver'} onClick={moveToOAuthProvider}>
       <StyledIconWrapper
         style={{
           margin: '4px 53px 4px 20px',

--- a/src/components/common/Buttons/IconButton/NaverButton.tsx
+++ b/src/components/common/Buttons/IconButton/NaverButton.tsx
@@ -1,7 +1,9 @@
 import NaverIcon from '@/assets/icons/NaverIcon'
 import { OAuthButtonProps, StyledIconWrapper } from '@/components/common/Buttons/IconButton'
-import { StyledButtonWrapper } from '@/components/common/Buttons/IconButton/KakaoButton'
-import { Text } from '@/components/common/Text'
+import {
+  StyledButtonText,
+  StyledButtonWrapper,
+} from '@/components/common/Buttons/IconButton/KakaoButton'
 import { palette } from '@/styles/palette'
 const NaverButton = ({ moveToOAuthProvider }: OAuthButtonProps) => {
   return (
@@ -9,7 +11,7 @@ const NaverButton = ({ moveToOAuthProvider }: OAuthButtonProps) => {
       <StyledIconWrapper>
         <NaverIcon width={53} height={53} iconWidth={20} iconHeight={20} borderRadius={10} />
       </StyledIconWrapper>
-      <Text
+      <StyledButtonText
         font={'Body_18'}
         fontWeight={600}
         letterSpacing={-1}
@@ -21,7 +23,7 @@ const NaverButton = ({ moveToOAuthProvider }: OAuthButtonProps) => {
         }}
       >
         {'네이버로 시작'}
-      </Text>
+      </StyledButtonText>
     </StyledButtonWrapper>
   )
 }

--- a/src/components/common/Buttons/IconButton/NaverButton.tsx
+++ b/src/components/common/Buttons/IconButton/NaverButton.tsx
@@ -1,16 +1,12 @@
 import NaverIcon from '@/assets/icons/NaverIcon'
 import { OAuthButtonProps, StyledIconWrapper } from '@/components/common/Buttons/IconButton'
-import { ButtonWrapper } from '@/components/common/Buttons/IconButton/KakaoButton'
+import { StyledButtonWrapper } from '@/components/common/Buttons/IconButton/KakaoButton'
 import { Text } from '@/components/common/Text'
 import { palette } from '@/styles/palette'
 const NaverButton = ({ moveToOAuthProvider }: OAuthButtonProps) => {
   return (
-    <ButtonWrapper buttonTheme={'naver'} onClick={moveToOAuthProvider}>
-      <StyledIconWrapper
-        style={{
-          margin: '4px 53px 4px 20px',
-        }}
-      >
+    <StyledButtonWrapper buttonTheme={'naver'} onClick={moveToOAuthProvider}>
+      <StyledIconWrapper>
         <NaverIcon width={53} height={53} iconWidth={20} iconHeight={20} borderRadius={10} />
       </StyledIconWrapper>
       <Text
@@ -26,7 +22,7 @@ const NaverButton = ({ moveToOAuthProvider }: OAuthButtonProps) => {
       >
         {'네이버로 시작'}
       </Text>
-    </ButtonWrapper>
+    </StyledButtonWrapper>
   )
 }
 

--- a/src/components/common/Buttons/IconButton/index.tsx
+++ b/src/components/common/Buttons/IconButton/index.tsx
@@ -47,11 +47,16 @@ export const StyledIconWrapper = styled.div<{
 }>`
   width: 35px;
   height: 35px;
+  margin: 4px 38px 4px 20px;
   border-radius: ${(props) => props.borderRadius};
   background-color: ${(props) => props.backgroundColor};
   display: flex;
   justify-content: center;
   align-items: center;
+
+  @media (max-width: 280px) {
+    margin: 2px 10px 2px 10px;
+  }
 `
 
 export { InterestButton, KakaoButton, NaverButton, ParticularTopicButton, RandomMatchingButton }

--- a/src/components/common/Buttons/IconButton/index.tsx
+++ b/src/components/common/Buttons/IconButton/index.tsx
@@ -1,14 +1,20 @@
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 
+import {
+  iconButtonStyles,
+  IconButtonType,
+} from '@/components/common/Buttons/IconButton/IconButtonStyles'
+import InterestButton from '@/components/common/Buttons/IconButton/InterestButton'
+import KakaoButton from '@/components/common/Buttons/IconButton/KakaoButton'
+import NaverButton from '@/components/common/Buttons/IconButton/NaverButton'
+import ParticularTopicButton from '@/components/common/Buttons/IconButton/ParticularTopicButton'
+import RandomMatchingButton from '@/components/common/Buttons/IconButton/RandomMatchingButton'
 import { typo } from '@/styles/typo'
 
-import { iconButtonStyles, IconButtonType } from './IconButtonStyles'
-import InterestButton from './InterestButton'
-import KakaoButton from './KakaoButton'
-import NaverButton from './NaverButton'
-import ParticularTopicButton from './ParticularTopicButton'
-import RandomMatchingButton from './RandomMatchingButton'
+export type OAuthButtonProps = {
+  moveToOAuthProvider: () => void
+}
 
 export const StyledIconButtonWrapper = styled.button<{
   iconButtonType: IconButtonType

--- a/src/components/common/HeroImage/index.tsx
+++ b/src/components/common/HeroImage/index.tsx
@@ -2,22 +2,23 @@ import styled from '@emotion/styled'
 
 import LoginImage from '@/assets/LoginImage.svg'
 
-const HeroImage = () => {
+const HeroImage = ({ ...props }) => {
   return (
-    <ImageContainer>
+    <StyledHeroImageContainer {...props}>
       <StyleHeroImage src={LoginImage} />
-    </ImageContainer>
+    </StyledHeroImageContainer>
   )
 }
 
-const ImageContainer = styled.div`
+const StyledHeroImageContainer = styled.div`
   display: flex;
   justify-content: center;
 `
+
 const StyleHeroImage = styled.img`
   border-radius: 20px;
-  width: 306px;
-  height: 306px;
+  width: 350px;
+  height: 350px;
 `
 
 export default HeroImage

--- a/src/components/common/HeroImage/index.tsx
+++ b/src/components/common/HeroImage/index.tsx
@@ -19,6 +19,11 @@ const StyleHeroImage = styled.img`
   border-radius: 20px;
   width: 350px;
   height: 350px;
+
+  @media (max-width: 375px) {
+    width: 250px;
+    height: 250px;
+  }
 `
 
 export default HeroImage

--- a/src/components/common/Spacing/index.tsx
+++ b/src/components/common/Spacing/index.tsx
@@ -1,17 +1,26 @@
 /** @jsxImportSource @emotion/react */
-import { css } from '@emotion/react'
+import { css, SerializedStyles } from '@emotion/react'
 
 import { KeyOfPalette, theme } from '@/styles/theme'
 
-const Spacing = ({ size, color }: { size: number; color?: KeyOfPalette }) => {
+type SpacingProps = {
+  size: number
+  color?: KeyOfPalette
+  css?: SerializedStyles
+}
+
+const Spacing = ({ size, color, css: customCss }: SpacingProps) => {
   return (
     <div
-      css={css`
-        height: ${size}px;
-        width: 100%;
-        background-color: ${color ? `${theme.palette[color]}` : 'transparent'};
-      `}
-    ></div>
+      css={[
+        css`
+          height: ${size}px;
+          width: 100%;
+          background-color: ${color ? `${theme.palette[color]}` : 'transparent'};
+        `,
+        customCss, // 사용자 정의 스타일을 적용
+      ]}
+    />
   )
 }
 

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -39,9 +39,9 @@ const Login = () => {
             }
           `}
         />
-        <Text font={'Body_32'} fontWeight={700} letterSpacing={-1}>
+        <StyledHeaderText font={'Body_32'} fontWeight={700} letterSpacing={-1}>
           {'☕️커피밋'}
-        </Text>
+        </StyledHeaderText>
         <Spacing
           size={50}
           css={css`
@@ -51,9 +51,9 @@ const Login = () => {
           `}
         />
 
-        <Text font={'Body_18'} fontWeight={500} letterSpacing={-1}>
+        <StyledSubText font={'Body_18'} fontWeight={500} letterSpacing={-1}>
           {'회사의 경계를 넘어, '}
-        </Text>
+        </StyledSubText>
         <Spacing
           size={10}
           css={css`
@@ -63,9 +63,9 @@ const Login = () => {
           `}
         />
 
-        <Text font={'Body_18'} fontWeight={500} letterSpacing={-1}>
+        <StyledSubText font={'Body_18'} fontWeight={500} letterSpacing={-1}>
           {' 새로운 대화의 세계를 탐험하세요!'}
-        </Text>
+        </StyledSubText>
         <Spacing
           size={80}
           css={css`
@@ -124,5 +124,17 @@ const StyledLoginContainer = styled.div`
   border-radius: 20px;
   text-align: center;
   padding-bottom: 10%;
+`
+
+const StyledHeaderText = styled(Text)`
+  @media (max-width: 280px) {
+    font-size: 24px;
+  }
+`
+
+const StyledSubText = styled(Text)`
+  @media (max-width: 280px) {
+    font-size: 14px;
+  }
 `
 export default Login

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 
 import { KakaoButton, NaverButton } from '@/components/common/Buttons/IconButton'
@@ -30,21 +31,49 @@ const Login = () => {
         }}
       />
       <StyledLoginContainer>
-        <Spacing size={45} />
+        <Spacing
+          size={45}
+          css={css`
+            @media (max-width: 375px) {
+              height: ${45 * 0.75}px;
+            }
+          `}
+        />
         <Text font={'Body_32'} fontWeight={700} letterSpacing={-1}>
           {'☕️커피밋'}
         </Text>
-        <Spacing size={50} />
+        <Spacing
+          size={50}
+          css={css`
+            @media (max-width: 375px) {
+              height: ${50 * 0.75}px;
+            }
+          `}
+        />
 
         <Text font={'Body_18'} fontWeight={500} letterSpacing={-1}>
           {'회사의 경계를 넘어, '}
         </Text>
-        <Spacing size={10} />
+        <Spacing
+          size={10}
+          css={css`
+            @media (max-width: 375px) {
+              height: ${10 * 0.75}px;
+            }
+          `}
+        />
 
         <Text font={'Body_18'} fontWeight={500} letterSpacing={-1}>
           {' 새로운 대화의 세계를 탐험하세요!'}
         </Text>
-        <Spacing size={80} />
+        <Spacing
+          size={80}
+          css={css`
+            @media (max-width: 375px) {
+              height: ${80 * 0.75}px;
+            }
+          `}
+        />
 
         <StyledOauthWrapper>
           <NaverButton
@@ -52,7 +81,14 @@ const Login = () => {
               handleMoveToAuthProvider('naver')
             }}
           />
-          <Spacing size={16} />
+          <Spacing
+            size={16}
+            css={css`
+              @media (max-width: 375px) {
+                height: ${16 * 0.75}px;
+              }
+            `}
+          />
           <KakaoButton
             moveToOAuthProvider={() => {
               handleMoveToAuthProvider('kakao')
@@ -66,11 +102,11 @@ const Login = () => {
 
 const StyledLoginOuterWrapper = styled.div`
   background-color: ${palette.SKY_BLUE};
+  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100vh;
 `
 
 const StyledOauthWrapper = styled.div`
@@ -87,5 +123,6 @@ const StyledLoginContainer = styled.div`
   background-color: ${palette.WHITE};
   border-radius: 20px;
   text-align: center;
+  padding-bottom: 10%;
 `
 export default Login

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -4,14 +4,32 @@ import { KakaoButton, NaverButton } from '@/components/common/Buttons/IconButton
 import HeroImage from '@/components/common/HeroImage'
 import Spacing from '@/components/common/Spacing'
 import { Text } from '@/components/common/Text'
+import useAuthStore from '@/store/AuthStore'
 import { palette } from '@/styles/palette'
 
-const Login = () => {
-  return (
-    <LoginOuterWrapper>
-      <HeroImage />
+export type Provider = 'naver' | 'kakao'
 
-      <StyledContainer>
+const BASE_URL = import.meta.env.VITE_BASE_URL
+
+const Login = () => {
+  const setProvider = useAuthStore((state) => state.setProvider)
+
+  const handleMoveToAuthProvider = async (provider: Provider) => {
+    window.location.assign(`${BASE_URL}/v1/oauth2.0/${provider}`)
+    setProvider(provider)
+  }
+
+  return (
+    <StyledLoginOuterWrapper>
+      <HeroImage
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          flex: 1,
+        }}
+      />
+      <StyledLoginContainer>
         <Spacing size={45} />
         <Text font={'Body_32'} fontWeight={700} letterSpacing={-1}>
           {'☕️커피밋'}
@@ -28,28 +46,42 @@ const Login = () => {
         </Text>
         <Spacing size={80} />
 
-        <OauthWrapper>
-          <NaverButton />
+        <StyledOauthWrapper>
+          <NaverButton
+            moveToOAuthProvider={() => {
+              handleMoveToAuthProvider('naver')
+            }}
+          />
           <Spacing size={16} />
-          <KakaoButton />
-        </OauthWrapper>
-      </StyledContainer>
-    </LoginOuterWrapper>
+          <KakaoButton
+            moveToOAuthProvider={() => {
+              handleMoveToAuthProvider('kakao')
+            }}
+          />
+        </StyledOauthWrapper>
+      </StyledLoginContainer>
+    </StyledLoginOuterWrapper>
   )
 }
 
-const LoginOuterWrapper = styled.div`
+const StyledLoginOuterWrapper = styled.div`
   background-color: ${palette.SKY_BLUE};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
 `
 
-const OauthWrapper = styled.div`
+const StyledOauthWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: column;
 `
 
-const StyledContainer = styled.div`
+const StyledLoginContainer = styled.div`
+  flex: 1;
   width: 100%;
   height: 441px;
   background-color: ${palette.WHITE};

--- a/src/pages/loginPending/LoginPending.tsx
+++ b/src/pages/loginPending/LoginPending.tsx
@@ -1,0 +1,57 @@
+import styled from '@emotion/styled'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { PulseLoader } from 'react-spinners'
+
+import { axiosAPI } from '@/apis/axios'
+import useAuthStore from '@/store/AuthStore'
+import { palette } from '@/styles/palette'
+
+const LoginPending = () => {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const code = searchParams.get('code')
+  const setToken = useAuthStore((state) => state.setAuthTokens)
+  const provider = useAuthStore((state) => state.provider)
+
+  const routeAuthInfo = async () => {
+    await axiosAPI
+      .get(`${import.meta.env.VITE_BASE_URL}/v1/users/login/${provider}?code=${code}`)
+      .then((res) => {
+        setToken({
+          accessToken: res.data.accessToken,
+          refreshToken: res.data.refreshToken,
+        })
+      })
+      .catch((err) => {
+        if (err.response.status === 400) {
+          navigate('/register/user')
+        }
+      })
+  }
+
+  routeAuthInfo()
+
+  return (
+    <StyledLoginPending>
+      <PulseLoader
+        size={10}
+        speedMultiplier={0.3}
+        cssOverride={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      />
+    </StyledLoginPending>
+  )
+}
+
+const StyledLoginPending = styled.div`
+  background-color: ${palette.SKY_BLUE};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+`
+
+export default LoginPending

--- a/src/pages/loginPending/LoginPending.tsx
+++ b/src/pages/loginPending/LoginPending.tsx
@@ -9,13 +9,13 @@ import { palette } from '@/styles/palette'
 const LoginPending = () => {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
-  const code = searchParams.get('code')
+  const authCode = searchParams.get('code')
   const setToken = useAuthStore((state) => state.setAuthTokens)
   const provider = useAuthStore((state) => state.provider)
 
   const routeAuthInfo = async () => {
     await axiosAPI
-      .get(`${import.meta.env.VITE_BASE_URL}/v1/users/login/${provider}?code=${code}`)
+      .get(`${import.meta.env.VITE_BASE_URL}/v1/users/login/${provider}?code=${authCode}`)
       .then((res) => {
         setToken({
           accessToken: res.data.accessToken,
@@ -24,7 +24,7 @@ const LoginPending = () => {
       })
       .catch((err) => {
         if (err.response.status === 404) {
-          navigate('/register/user')
+          navigate('/register/user', { state: { authCode } })
         }
       })
   }

--- a/src/pages/loginPending/LoginPending.tsx
+++ b/src/pages/loginPending/LoginPending.tsx
@@ -23,7 +23,7 @@ const LoginPending = () => {
         })
       })
       .catch((err) => {
-        if (err.response.status === 400) {
+        if (err.response.status === 404) {
           navigate('/register/user')
         }
       })

--- a/src/pages/loginPending/index.tsx
+++ b/src/pages/loginPending/index.tsx
@@ -1,0 +1,14 @@
+import { Route, Routes } from 'react-router-dom'
+
+import LoginPending from '@/pages/loginPending/LoginPending'
+const LoginPendingPage = () => {
+  return (
+    <Routes>
+      <Route path={'/'} element={<LoginPending />}>
+        {' '}
+      </Route>
+    </Routes>
+  )
+}
+
+export default LoginPendingPage

--- a/src/pages/register/RegisterUser.tsx
+++ b/src/pages/register/RegisterUser.tsx
@@ -1,4 +1,10 @@
+import { useLocation } from 'react-router-dom'
+
 const Register = () => {
+  const location = useLocation()
+  const { authCode } = location.state || {}
+
+  console.log(authCode)
   return <div>{'Register'}</div>
 }
 

--- a/src/store/AuthStore.tsx
+++ b/src/store/AuthStore.tsx
@@ -1,0 +1,35 @@
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+
+import { Provider } from '@/pages/login/Login'
+
+type Tokens = {
+  accessToken: string
+  refreshToken: string
+}
+
+type AuthState = {
+  provider: Provider
+  authTokens?: Tokens
+  setProvider: (provider: Provider) => void
+  setAuthTokens: (authTokens: Tokens) => void
+}
+
+const useAuthStore = create(
+  persist<AuthState>(
+    (set) => ({
+      provider: 'kakao',
+      setProvider: (provider: Provider) => set(() => ({ provider })),
+      setAuthTokens: (authTokens: Tokens) =>
+        set(() => ({
+          authTokens,
+        })),
+    }),
+    {
+      name: 'auth-store',
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+)
+
+export default useAuthStore


### PR DESCRIPTION
## 이슈번호
<!-- - close 뒤에 이슈 달아주기 -->
close: #100 

## 작업 내용 설명
<!-- 스크린샷 및 작업내용을 적어주세요 -->
- 백엔드에서 `REDIRECT_URI`를 `https://coffee-meet.site`로 연결해줘서 로컬에서 테스트 할 땐 부득이 `http://localhost:5173`을 넣어줬습니다.
  - 실제 회원가입이 되어있지 않다면 `404` 상태 코드를 반환한다고 백엔드에서 전달받았습니다.
    - 회원가입 리다이렉트 상태 코드를 기존 `400` 에서 `404`로 수정했습니다.
  - Status Code가 400이면 회원가입 페이지(/register/user)로 라우팅 됩니다.
  - Status Code가 200이면 토큰을 `zustand persist`로 저장하도록 했습니다.
  - ![ezgif com-video-to-gif (19)](https://github.com/coffee-meet/frontend/assets/43228743/017ba9d5-90f1-4e91-b15e-7b46c84c6112)

- 로그인 페이지가 반응형 구조를 가지도록 수정했습니다
  - 갤럭시 폴드
    - ![image](https://github.com/coffee-meet/frontend/assets/43228743/d8a69f99-5017-47b3-ae41-b8a707e9370f)
  - 아이폰 SE
    - ![스크린샷 2023-11-09 오후 11 34 31](https://github.com/coffee-meet/frontend/assets/43228743/5659e1b3-7dd2-49bd-9fe8-ed92f1c120a9)
  - 전체화면
    - ![스크린샷 2023-11-09 오후 11 35 11](https://github.com/coffee-meet/frontend/assets/43228743/ca54b3fe-4eef-4cca-8d8e-753ed710dfa8)

- authCode 사용법
```tsx
const location = useLocation()
const { authCode } = location.state || {}

console.log(authCode) // cj2xwh7Ue5CTtPImEB2Mn8SRRShNstoLU7vsmXFdsIdrLlI0rSeZ9INXRsKKiUOAAABi7x3zQRyxKx5jTsi9A
```


## 리뷰어에게 한마디
<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->
