### PR TITLE
🐛 [Bug]: OAuth 인증 코드 분리 로직 추가

### DIFF
--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -16,8 +16,6 @@ axiosAPI.interceptors.request.use(
     // axios 설정값에 대해 작성합니다.
 
     config.headers['Authorization'] = `Bearer ${localStorage.getItem('jwt')}`
-
-
     return config
   },
   function (error) {

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -10,7 +10,7 @@ import { palette } from '@/styles/palette'
 
 export type Provider = 'NAVER' | 'KAKAO'
 
-const BASE_URL = import.meta.env.VITE_BASE_URL
+export const BASE_URL = import.meta.env.VITE_BASE_URL
 
 const Login = () => {
   const setProvider = useAuthStore((state) => state.setProvider)

--- a/src/pages/loginPending/LoginPending.tsx
+++ b/src/pages/loginPending/LoginPending.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 import { PulseLoader } from 'react-spinners'
 
 import { axiosAPI } from '@/apis/axios'
+import { BASE_URL } from '@/pages/login/Login.tsx'
 import useAuthStore from '@/store/AuthStore'
 import { palette } from '@/styles/palette'
 
@@ -13,6 +14,7 @@ const LoginPending = () => {
   const authCode = searchParams.get('code')
   const setToken = useAuthStore((state) => state.setAuthTokens)
   const provider = useAuthStore((state) => state.provider)
+  const { isNewUser, setIsNewUser } = useAuthStore()
   const routeAuthInfo = async () => {
     await axiosAPI
       .get(`/v1/users/login/${provider}?authCode=${authCode}`)
@@ -29,15 +31,19 @@ const LoginPending = () => {
       })
       .catch((err) => {
         if (err.response.status === 404) {
-          navigate('/register/user', { state: { authCode } })
-
           console.log('카카오 로그인 완료 & 정보 등록 안됨')
-
+          setIsNewUser(true)
+          window.location.replace(`${BASE_URL}/v1/oauth2.0/${provider}`)
         }
       })
   }
   useEffect(() => {
-    routeAuthInfo()
+    if (isNewUser) {
+      const authCode = searchParams.get('code')
+      navigate('/register/user', { state: { authCode } })
+    } else {
+      routeAuthInfo()
+    }
   }, [])
 
   return (

--- a/src/pages/register/RegisterCompany.tsx
+++ b/src/pages/register/RegisterCompany.tsx
@@ -3,7 +3,6 @@ import { useMutation } from '@tanstack/react-query'
 import { RefObject, useRef, useState } from 'react'
 import { MdWbSunny } from 'react-icons/md'
 import { MdOutlinePhotoCamera } from 'react-icons/md'
-
 import { useNavigate } from 'react-router-dom'
 
 import { axiosAPI } from '@/apis/axios'
@@ -157,7 +156,6 @@ const RegisterCompany = () => {
           isDarkMode: false,
         })
       })
-
   }
   // const registerCompanyMutation = useMutation((body: object) => registerCompanyData(body), {
   //   onSuccess: (response) => {

--- a/src/pages/register/RegisterCompany.tsx
+++ b/src/pages/register/RegisterCompany.tsx
@@ -14,6 +14,7 @@ import RegisterInput from '@/components/common/RegisterInput'
 import SelectorButtonContainer from '@/components/common/SelectorButtonContainer'
 import Spacing from '@/components/common/Spacing'
 import useToast from '@/hooks/useToast'
+import useAuthStore from '@/store/AuthStore.tsx'
 import useInterestStore from '@/store/InterestStore'
 import useThemeStore from '@/store/ThemeStore'
 import { palette } from '@/styles/palette'
@@ -48,6 +49,7 @@ const RegisterCompany = () => {
   const formData = new FormData()
   const imgRef = useRef<HTMLInputElement>(null) as RefObject<HTMLInputElement>
   const [uploadedURL, setUploadedURL] = useState('')
+  const { setIsNewUser } = useAuthStore()
 
   const handleClickEmailVerify = async (email: string) => {
     console.log(email)
@@ -147,6 +149,7 @@ const RegisterCompany = () => {
           type: 'success',
           isDarkMode: false,
         })
+        setIsNewUser(false)
         navigate('/')
       })
       .catch(() => {

--- a/src/pages/register/RegisterUser.tsx
+++ b/src/pages/register/RegisterUser.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { useMutation } from '@tanstack/react-query'
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { MdWbSunny } from 'react-icons/md'
 import { useNavigate } from 'react-router-dom'
 import { useLocation } from 'react-router-dom'
@@ -45,31 +45,6 @@ const RegisterUser = () => {
   const { provider } = useAuthStore()
   const { showToast } = useToast()
   const isDarkMode = useThemeStore((state) => state.isDarkMode)
-  const setToken = useAuthStore((state) => state.setAuthTokens)
-
-  const routeAuthInfo = async () => {
-    await axiosAPI
-      .get(`/v1/users/login/${provider}?authCode=${authCode}`)
-      .then((res) => {
-        console.log(res.data.accessToken)
-        localStorage.setItem('jwt', res.data.accessToken)
-        localStorage.setItem('nickname', res.data.nickname)
-
-        setToken({
-          accessToken: res.data.accessToken,
-          refreshToken: res.data.refreshToken,
-        })
-      })
-      .catch((err) => {
-        if (err.response.status === 404) {
-          navigate('/register/user', { state: { authCode } })
-          console.log('실패패패')
-        }
-      })
-  }
-  useEffect(() => {
-    routeAuthInfo()
-  }, [])
 
   const getNicknameValid = async (nickname: string) => {
     return await axiosAPI.get(`/v1/users/duplicate?nickname=${nickname}`)
@@ -78,7 +53,6 @@ const RegisterUser = () => {
     onSuccess: (response) => {
       if (response.status == 200) {
         //사용가능한 닉네임일 경우
-        console.log(response)
         setDoubleChecked(true)
         setNicknameDuplicated(false)
       } else {
@@ -149,8 +123,6 @@ const RegisterUser = () => {
 
   const registerMutation = useMutation((body: object) => registerPost(body), {
     onSuccess: (response) => {
-      console.log(response)
-      console.log(response.data.accessToken)
       localStorage.setItem('jwt', response.data.accessToken)
       showToast({
         message: '닉네임, 관심사 정보 등록을 완료했습니다!',

--- a/src/store/AuthStore.tsx
+++ b/src/store/AuthStore.tsx
@@ -10,7 +10,9 @@ type Tokens = {
 
 type AuthState = {
   provider: Provider
+  isNewUser: boolean
   authTokens?: Tokens
+  setIsNewUser: (isNewUser: boolean) => void
   setProvider: (provider: Provider) => void
   setAuthTokens: (authTokens: Tokens) => void
 }
@@ -18,7 +20,9 @@ type AuthState = {
 const useAuthStore = create(
   persist<AuthState>(
     (set) => ({
+      isNewUser: false,
       provider: 'KAKAO',
+      setIsNewUser: (isNewUser: boolean) => set(() => ({ isNewUser })),
       setProvider: (provider: Provider) => set(() => ({ provider })),
       setAuthTokens: (authTokens: Tokens) =>
         set(() => ({


### PR DESCRIPTION
## 이슈번호

close: #138 

## 작업 내용 설명
- 최초 로그인 여부를 판단할 수 있는 전역 상태 `isNew`를 추가했습니다!
- LoginPending에서 isNew의 값에 따라 인증 코드를 그대로 활용하여 로그인 하거나, 새로 발급받아 `register/user`로 전달하게 됩니다.

## 리뷰어에게 한마디
파이팅!
