### PR TITLE
[Feature]: BE OAuth 인증 로직 변경에 따른 적용

### DIFF
--- a/src/components/common/AppHeader/index.tsx
+++ b/src/components/common/AppHeader/index.tsx
@@ -43,6 +43,7 @@ const StyledAppHeaderSmallText = styled(Text)<Pick<AppHeaderProps, 'isDarkMode'>
 
 type AppHeaderProps = {
   nickname: string
+  profileImageUrl: string
   isDarkMode: boolean
   height?: string
   toggleDarkMode: () => void
@@ -50,12 +51,19 @@ type AppHeaderProps = {
 
 /**
  * @param nickname - 유저 닉네임
+ * @param profileImageUrl - 유저 프로필 이미지 URL
  * @param isDarkMode - 다크모드 여부
  * @param height - 컴포넌트 높이
  * @param toggleDarkMode - 다크모드 토글 함수
  */
 
-const AppHeader = ({ nickname, isDarkMode, height, toggleDarkMode }: AppHeaderProps) => {
+const AppHeader = ({
+  nickname,
+  profileImageUrl,
+  isDarkMode,
+  height,
+  toggleDarkMode,
+}: AppHeaderProps) => {
   const navigate = useNavigate()
   const moveFromAppHeader = (path: string) => {
     navigate(`/${path}`)
@@ -72,7 +80,7 @@ const AppHeader = ({ nickname, isDarkMode, height, toggleDarkMode }: AppHeaderPr
         <Avatar
           width={49}
           height={49}
-          imgUrl={''}
+          imgUrl={profileImageUrl}
           margin={'0'}
           style={{
             cursor: 'pointer',

--- a/src/components/common/SelectorButton/index.tsx
+++ b/src/components/common/SelectorButton/index.tsx
@@ -2,10 +2,13 @@ import styled from '@emotion/styled'
 import { useState } from 'react'
 
 import useInterestStore from '@/store/InterestStore'
+import useJobStore from '@/store/JobStore.tsx'
 import { palette } from '@/styles/palette'
+
 type SelectorButtonProps = {
   isDarkMode: boolean
   buttonName: string
+  type: 'interest' | 'job'
   isButtonClicked?: (selected: boolean) => void
   isButtonSelected?: boolean
   isMaxLengthReached: boolean
@@ -14,6 +17,7 @@ type SelectorButtonProps = {
 const SelectorButton = ({
   isDarkMode,
   buttonName,
+  type,
   isButtonClicked,
   isButtonSelected: propIsButtonSelected = false,
   isMaxLengthReached = false,
@@ -37,6 +41,7 @@ const SelectorButton = ({
   const [backgroundColor, setBackgroundColor] = useState(initialBackgroundColor)
   const [currentTextColor, setCurrentTextColor] = useState(defaultSettings.textColor)
   const { interestList, setInterestList } = useInterestStore()
+  const { setJobInfo } = useJobStore()
 
   const handleButtonClick = () => {
     const isSelected = backgroundColor !== defaultSettings.selectedButtonColor
@@ -47,7 +52,19 @@ const SelectorButton = ({
     }
     setIsButtonSelected(isSelected)
 
-    setInterestList([...interestList, buttonName])
+    if (type === 'interest') {
+      if (isSelected) {
+        setInterestList([...interestList, buttonName])
+      } else {
+        setInterestList(interestList.filter((v) => v != buttonName))
+      }
+    } else {
+      if (isSelected) {
+        setJobInfo(buttonName)
+      } else {
+        setJobInfo('')
+      }
+    }
     setBackgroundColor(
       isSelected ? defaultSettings.selectedButtonColor : defaultSettings.defaultButtonColor,
     )
@@ -57,7 +74,11 @@ const SelectorButton = ({
       setCurrentTextColor(isSelected ? palette.WHITE : defaultSettings.textColor)
     }
     if (isButtonClicked) isButtonClicked(isSelected)
-    if (!isSelected) setInterestList(interestList.filter((v) => v != buttonName))
+    if (type === 'interest') {
+      if (!isSelected) setInterestList(interestList.filter((v) => v != buttonName))
+    } else {
+      if (!isSelected) setJobInfo('')
+    }
   }
 
   return (

--- a/src/components/common/SelectorButtonContainer/index.tsx
+++ b/src/components/common/SelectorButtonContainer/index.tsx
@@ -8,12 +8,14 @@ import SelectorButton from '@/components/common/SelectorButton'
 import { palette } from '@/styles/palette'
 type SelectorButtonContainerProps = {
   isDarkMode: boolean
+  type: 'interest' | 'job'
   buttonNames: string[]
   maxLength: number
 }
 
 const SelectorButtonContainer = ({
   isDarkMode,
+  type,
   buttonNames,
   maxLength,
 }: SelectorButtonContainerProps) => {
@@ -53,6 +55,7 @@ const SelectorButtonContainer = ({
             key={index}
             isDarkMode={isDarkMode}
             buttonName={name}
+            type={type}
             isButtonClicked={handleButtonSelection}
             isMaxLengthReached={selectedCount >= maxLength}
             isButtonSelected={false}

--- a/src/pages/admin/components/AdminInquiryBtn.tsx
+++ b/src/pages/admin/components/AdminInquiryBtn.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { useNavigate } from 'react-router-dom'
 
-import InquiryImage from '@/assets/images/inquiry.svg'
+import InquiryImage from '@/assets/images/inquiryImage.svg'
 import { Text } from '@/components/common/Text'
 import { palette } from '@/styles/palette'
 const AdminInquiryBtn = () => {

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 import AppHeader from '@/components/common/AppHeader'
 import { ParticularTopicButton } from '@/components/common/Buttons/IconButton'
@@ -8,16 +10,36 @@ import PageContainer from '@/components/common/PageContainer'
 import { Text } from '@/components/common/Text'
 import Card from '@/components/home/Card'
 import useToast from '@/hooks/useToast'
+import useAuthStore from '@/store/AuthStore.tsx'
 import useThemeStore from '@/store/ThemeStore'
 import { palette } from '@/styles/palette'
 
 const Home = () => {
   const nickname = '우땅'
+  const [nickname, setNickname] = useState('')
+  const [profileImageUrl, setProfileImageUrl] = useState('')
   const isDarkMode = useThemeStore((state) => state.isDarkMode)
   const toggleDarkMode = useThemeStore((state) => state.toggleDarkMode)
+  const { authTokens } = useAuthStore()
   const [isMatching, setIsMatching] = useState(false)
+  const navigate = useNavigate()
 
   const { showToast } = useToast()
+
+  useEffect(() => {
+    if (!authTokens) {
+      showToast({
+        message: '로그인이 필요한 서비스입니다.',
+        type: 'warning',
+        isDarkMode,
+      })
+      navigate('/login')
+    }
+    if (authTokens) {
+      setNickname(localStorage.getItem('nickname') || '')
+      setProfileImageUrl(localStorage.getItem('profileImageUrl') || '')
+    }
+  }, [])
 
   return (
     <GradationBackground isDarkMode={isDarkMode}>

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
@@ -15,7 +14,6 @@ import useThemeStore from '@/store/ThemeStore'
 import { palette } from '@/styles/palette'
 
 const Home = () => {
-  const nickname = '우땅'
   const [nickname, setNickname] = useState('')
   const [profileImageUrl, setProfileImageUrl] = useState('')
   const isDarkMode = useThemeStore((state) => state.isDarkMode)
@@ -43,7 +41,12 @@ const Home = () => {
 
   return (
     <GradationBackground isDarkMode={isDarkMode}>
-      <AppHeader nickname={nickname} isDarkMode={isDarkMode} toggleDarkMode={toggleDarkMode} />
+      <AppHeader
+        nickname={nickname}
+        profileImageUrl={profileImageUrl}
+        isDarkMode={isDarkMode}
+        toggleDarkMode={toggleDarkMode}
+      />
       <PageContainer
         height={'80%'}
         isDarkMode={isDarkMode}

--- a/src/pages/loginPending/LoginPending.tsx
+++ b/src/pages/loginPending/LoginPending.tsx
@@ -15,9 +15,6 @@ interface LoginResponse {
   refreshToken: string
   nickname: string
   profileImageUrl: string
-  companyName: string
-  department: string
-  interests: string[]
 }
 
 const LoginPending = () => {
@@ -32,17 +29,8 @@ const LoginPending = () => {
     await axiosAPI
       .get<LoginResponse>(`/v1/users/login/${provider}?authCode=${authCode}`)
       .then((res) => {
-        const {
-          userId,
-          accessToken,
-          refreshToken,
-          isRegistered,
-          nickname,
-          profileImageUrl,
-          companyName,
-          department,
-          interests,
-        } = res.data
+        const { userId, accessToken, refreshToken, isRegistered, nickname, profileImageUrl } =
+          res.data
 
         if (!isRegistered) {
           navigate('/register/user', { state: { userId } })
@@ -50,13 +38,16 @@ const LoginPending = () => {
 
         if (isRegistered) {
           localStorage.setItem('jwt', accessToken)
+          // TODO: 아래 3개의 정보는 추후 AuthStore에서 관리?
+          localStorage.setItem('userId', userId.toString())
           localStorage.setItem('nickname', nickname)
+          localStorage.setItem('profileImageUrl', profileImageUrl)
           setToken({
             accessToken: accessToken,
             refreshToken: refreshToken,
           })
           navigate('/', {
-            state: { userId, nickname, profileImageUrl, companyName, department, interests },
+            state: { userId, nickname, profileImageUrl },
           })
         }
       })

--- a/src/pages/loginPending/LoginPending.tsx
+++ b/src/pages/loginPending/LoginPending.tsx
@@ -38,13 +38,8 @@ const LoginPending = () => {
       })
   }
   useEffect(() => {
-    if (isNewUser) {
-      const authCode = searchParams.get('code')
-      navigate('/register/user', { state: authCode })
-    } else {
-      routeAuthInfo()
-    }
-  })
+    routeAuthInfo()
+  }, [])
 
   return (
     <StyledLoginPending>

--- a/src/pages/profile/ProfileDefault.tsx
+++ b/src/pages/profile/ProfileDefault.tsx
@@ -20,6 +20,7 @@ import Spacing from '@/components/common/Spacing'
 import { Text, TextWrapper } from '@/components/common/Text'
 import { useModal } from '@/hooks/useModal'
 import useToast from '@/hooks/useToast'
+import useAuthStore from '@/store/AuthStore.tsx'
 import useThemeStore from '@/store/ThemeStore'
 import { palette } from '@/styles/palette'
 
@@ -35,6 +36,12 @@ const ProfileDefault = () => {
       mainText: '로그아웃 하시겠습니까?',
       subText: '로그아웃 시 로그인 화면으로 이동합니다.',
       okFunc: () => {
+        // TODO: 명령형 -> 선언형 로직으로 변경
+        localStorage.setItem('jwt', '')
+        localStorage.removeItem('userId')
+        localStorage.removeItem('nickname')
+        localStorage.removeItem('profileImageUrl')
+        useAuthStore.persist.clearStorage()
         navigate('/login')
       },
       type: 'warn',

--- a/src/pages/register/RegisterCompany.tsx
+++ b/src/pages/register/RegisterCompany.tsx
@@ -131,7 +131,10 @@ const RegisterCompany = () => {
     formData.append('userId', userId)
     companyName.current && formData.append('companyName', companyName.current.value)
     emailRef.current && formData.append('companyEmail', emailRef.current.value)
-    formData.append('department', JSON.stringify(interestList))
+    formData.append('department', jobInfo)
+    if (imgRef.current && imgRef.current?.files) {
+      formData.append('businessCard', imgRef.current?.files[0])
+    }
 
     registerCompanyData(formData)
   }

--- a/src/pages/register/RegisterCompany.tsx
+++ b/src/pages/register/RegisterCompany.tsx
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query'
 import { RefObject, useRef, useState } from 'react'
 import { MdWbSunny } from 'react-icons/md'
 import { MdOutlinePhotoCamera } from 'react-icons/md'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { axiosAPI } from '@/apis/axios'
 import AlertText from '@/components/common/AlertText'
@@ -37,6 +37,7 @@ const RegisterCompany = () => {
     '법률/집행기관',
   ]
   const navigate = useNavigate()
+  const userId = useLocation().state.userId
   const companyName = useRef<HTMLInputElement>(null)
   const emailRef = useRef<HTMLInputElement>(null)
   const codeRef = useRef<HTMLInputElement>(null)
@@ -52,6 +53,7 @@ const RegisterCompany = () => {
   const handleClickEmailVerify = async (email: string) => {
     console.log(email)
     return await axiosAPI.post(`/v1/certification/users/me/company-mail`, {
+      userId: userId,
       companyEmail: emailRef.current && emailRef.current.value,
     })
   }
@@ -88,6 +90,7 @@ const RegisterCompany = () => {
   const checkEmailCode = async () => {
     setCodeChecked(true)
     const response = await axiosAPI.post('/v1/certification/users/me/company-mail/verification', {
+      userId: userId,
       verificationCode: codeRef.current && codeRef.current.value,
     })
     if (response.status == 200) setIsCodeSame(true)
@@ -125,6 +128,7 @@ const RegisterCompany = () => {
       })
       return
     }
+    formData.append('userId', userId)
     companyName.current && formData.append('companyName', companyName.current.value)
     emailRef.current && formData.append('companyEmail', emailRef.current.value)
     formData.append('department', JSON.stringify(interestList))

--- a/src/pages/register/RegisterCompany.tsx
+++ b/src/pages/register/RegisterCompany.tsx
@@ -150,11 +150,11 @@ const RegisterCompany = () => {
       })
       .then(() => {
         showToast({
-          message: '회사 정보 등록 완료! 메인 홈으로 이동합니다.',
+          message: '회사 정보 등록 완료! 다시 로그인 해주세요!',
           type: 'success',
           isDarkMode: false,
         })
-        navigate('/')
+        navigate('/login')
       })
       .catch(() => {
         showToast({

--- a/src/pages/register/RegisterCompany.tsx
+++ b/src/pages/register/RegisterCompany.tsx
@@ -14,7 +14,7 @@ import RegisterInput from '@/components/common/RegisterInput'
 import SelectorButtonContainer from '@/components/common/SelectorButtonContainer'
 import Spacing from '@/components/common/Spacing'
 import useToast from '@/hooks/useToast'
-import useInterestStore from '@/store/InterestStore'
+import useJobStore from '@/store/JobStore.tsx'
 import useThemeStore from '@/store/ThemeStore'
 import { palette } from '@/styles/palette'
 import { typo } from '@/styles/typo'
@@ -42,7 +42,7 @@ const RegisterCompany = () => {
   const codeRef = useRef<HTMLInputElement>(null)
   const [isCodeSame, setIsCodeSame] = useState<null | boolean>(null)
   const [codeChecked, setCodeChecked] = useState<null | boolean>(null)
-  const { interestList } = useInterestStore() //여기서 회사 직무 list 저장한거 get해옴
+  const { jobInfo } = useJobStore()
   const { showToast } = useToast()
   const isDarkMode = useThemeStore((state) => state.isDarkMode)
   const formData = new FormData()
@@ -249,8 +249,9 @@ const RegisterCompany = () => {
         <FlexBox direction={'column'}>
           <SelectorButtonContainer
             isDarkMode={false}
+            type={'job'}
             buttonNames={JobList}
-            maxLength={4}
+            maxLength={1}
           ></SelectorButtonContainer>
         </FlexBox>
         <Spacing size={10} />

--- a/src/pages/register/RegisterCompany.tsx
+++ b/src/pages/register/RegisterCompany.tsx
@@ -14,7 +14,6 @@ import RegisterInput from '@/components/common/RegisterInput'
 import SelectorButtonContainer from '@/components/common/SelectorButtonContainer'
 import Spacing from '@/components/common/Spacing'
 import useToast from '@/hooks/useToast'
-import useAuthStore from '@/store/AuthStore.tsx'
 import useInterestStore from '@/store/InterestStore'
 import useThemeStore from '@/store/ThemeStore'
 import { palette } from '@/styles/palette'
@@ -49,7 +48,6 @@ const RegisterCompany = () => {
   const formData = new FormData()
   const imgRef = useRef<HTMLInputElement>(null) as RefObject<HTMLInputElement>
   const [uploadedURL, setUploadedURL] = useState('')
-  const { setIsNewUser } = useAuthStore()
 
   const handleClickEmailVerify = async (email: string) => {
     console.log(email)
@@ -149,7 +147,6 @@ const RegisterCompany = () => {
           type: 'success',
           isDarkMode: false,
         })
-        setIsNewUser(false)
         navigate('/')
       })
       .catch(() => {

--- a/src/pages/register/RegisterUser.tsx
+++ b/src/pages/register/RegisterUser.tsx
@@ -127,7 +127,7 @@ const RegisterUser = () => {
         isDarkMode,
       })
 
-      navigate('/register/company')
+      navigate('/register/company', { state: { userId: userId } })
     },
     onError: (err) => {
       console.log(err)

--- a/src/pages/register/RegisterUser.tsx
+++ b/src/pages/register/RegisterUser.tsx
@@ -189,6 +189,7 @@ const RegisterUser = () => {
       <FlexBox direction={'column'}>
         <SelectorButtonContainer
           isDarkMode={false}
+          type={'interest'}
           buttonNames={InterestList}
           maxLength={4}
         ></SelectorButtonContainer>

--- a/src/pages/register/RegisterUser.tsx
+++ b/src/pages/register/RegisterUser.tsx
@@ -119,8 +119,7 @@ const RegisterUser = () => {
   }
 
   const registerMutation = useMutation((body: object) => registerPost(body), {
-    onSuccess: (response) => {
-      localStorage.setItem('jwt', response.data.accessToken)
+    onSuccess: () => {
       showToast({
         message: '닉네임, 관심사 정보 등록을 완료했습니다!',
         type: 'success',

--- a/src/pages/register/RegisterUser.tsx
+++ b/src/pages/register/RegisterUser.tsx
@@ -13,7 +13,6 @@ import RegisterInput from '@/components/common/RegisterInput'
 import SelectorButtonContainer from '@/components/common/SelectorButtonContainer'
 import Spacing from '@/components/common/Spacing'
 import useToast from '@/hooks/useToast'
-import useAuthStore from '@/store/AuthStore'
 import useInterestStore from '@/store/InterestStore'
 import useThemeStore from '@/store/ThemeStore'
 import { palette } from '@/styles/palette'
@@ -36,13 +35,12 @@ const RegisterUser = () => {
     '반려동물',
   ]
   const navigate = useNavigate()
-  const authCode = useLocation().state
+  const userId = useLocation().state.userId
   const inputRef = useRef<HTMLInputElement>(null)
   const [doubleChecked, setDoubleChecked] = useState<null | boolean>(false)
   const [nicknameDuplicated, setNicknameDuplicated] = useState<null | boolean>(null)
   let nickname = ''
   const { interestList } = useInterestStore()
-  const { provider } = useAuthStore()
   const { showToast } = useToast()
   const isDarkMode = useThemeStore((state) => state.isDarkMode)
 
@@ -107,10 +105,9 @@ const RegisterUser = () => {
       console.log(nickname, interestList)
       if (doubleChecked && inputRef.current !== null && interestList.length > 0) {
         const body = {
-          authCode: authCode,
+          userId: userId,
           nickname: inputRef.current.value,
           keywords: interestList,
-          oAuthProvider: provider,
         }
         console.log(body)
         registerMutation.mutate(body)

--- a/src/store/AuthStore.tsx
+++ b/src/store/AuthStore.tsx
@@ -10,9 +10,7 @@ type Tokens = {
 
 type AuthState = {
   provider: Provider
-  isNewUser: boolean
   authTokens?: Tokens
-  setIsNewUser: (isNewUser: boolean) => void
   setProvider: (provider: Provider) => void
   setAuthTokens: (authTokens: Tokens) => void
 }
@@ -20,9 +18,7 @@ type AuthState = {
 const useAuthStore = create(
   persist<AuthState>(
     (set) => ({
-      isNewUser: false,
       provider: 'KAKAO',
-      setIsNewUser: (isNewUser: boolean) => set(() => ({ isNewUser })),
       setProvider: (provider: Provider) => set(() => ({ provider })),
       setAuthTokens: (authTokens: Tokens) =>
         set(() => ({

--- a/src/store/AuthStore.tsx
+++ b/src/store/AuthStore.tsx
@@ -18,6 +18,7 @@ type AuthState = {
 const useAuthStore = create(
   persist<AuthState>(
     (set) => ({
+      authTokens: undefined,
       provider: 'KAKAO',
       setProvider: (provider: Provider) => set(() => ({ provider })),
       setAuthTokens: (authTokens: Tokens) =>

--- a/src/store/JobStore.tsx
+++ b/src/store/JobStore.tsx
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+type JobInfo = {
+  jobInfo: string
+  setJobInfo: (info: string) => void
+}
+
+const useJobStore = create<JobInfo>((set) => ({
+  jobInfo: '',
+  setJobInfo: (info) => set({ jobInfo: info }),
+}))
+
+export default useJobStore


### PR DESCRIPTION
## 이슈번호
close: #145 

## 작업 내용 설명
- [ ] BE OAuth 인증 로직 변경에 따라 클라이언트에서도 이를 적용했습니다!

- [ ] 카카오 로그인, 회원 가입, 회사 정보 등록 모두 테스트 완료하였습니다!
<테스트 과정 일부 캡처>
![Nov-22-2023 00-40-00](https://github.com/coffee-meet/frontend/assets/69716992/3a30cdbd-647b-4fac-bde8-b632afa575da)

![Nov-22-2023 00-40-19](https://github.com/coffee-meet/frontend/assets/69716992/612f55a3-44c5-429d-8a49-b8b514aaa9cf)


- [ ] 홈 페이지는 로그인하지 않으면 접근이 불가능하도록 변경했습니다!
![Nov-22-2023 00-30-21](https://github.com/coffee-meet/frontend/assets/69716992/b99aaef7-b1e7-48b4-80cb-fe97ffbc7532)

- [ ] 홈 페이지의 헤더 정보를 표시할 때 로그인한 계정 기반의 정보를 가져오도록 변경했습니다!


## 리뷰어에게 한마디
되는 곳 까지는 해봅시다! 파이팅!
