### PR TITLE
Fix: 회원 정보 등록 시점 변경

### DIFF
--- a/src/apis/register/registerUserInfo.ts
+++ b/src/apis/register/registerUserInfo.ts
@@ -1,0 +1,19 @@
+import { axiosAPI } from "@/apis/axios.ts";
+
+export type UserInfoType = {
+  userId: string;
+  nickname: string;
+  keywords: string[];
+};
+
+export const registerUserInfo = async (userInfo: UserInfoType) => {
+  try {
+    const res = await axiosAPI.post("/v1/users/sign-up", userInfo);
+    if (res.status !== 200) {
+      throw new Error("register user info failed!");
+    }
+  } catch (err) {
+    console.log(err);
+    throw err;
+  }
+};

--- a/src/pages/register/RegisterCompany.tsx
+++ b/src/pages/register/RegisterCompany.tsx
@@ -9,6 +9,8 @@ import styled from "@emotion/styled";
 import { zodResolver } from "@hookform/resolvers/zod";
 import getEmailValid from "@/apis/register/getEmailValid.ts";
 import registerCompanyInfo from "@/apis/register/registerCompanyInfo.ts";
+import type { UserInfoType } from "@/apis/register/registerUserInfo.ts";
+import { registerUserInfo } from "@/apis/register/registerUserInfo.ts";
 import sendEmailValidCode from "@/apis/register/sendEmailValidCode.ts";
 import AlertText from "@/components/common/AlertText";
 import BackChevron from "@/components/common/BackChevron";
@@ -27,7 +29,7 @@ const RegisterCompany = () => {
   const navigate = useNavigate();
   const { showToast } = useToast();
   const isDarkMode = useThemeStore((state) => state.isDarkMode);
-  const userId = useLocation().state.userId;
+  const userInfo: UserInfoType = useLocation().state;
   const [isCodeSame, setIsCodeSame] = useState<null | boolean>(null);
   const [codeChecked, setCodeChecked] = useState<null | boolean>(null);
   const [uploadedURL, setUploadedURL] = useState("");
@@ -58,7 +60,7 @@ const RegisterCompany = () => {
       type: "info",
       isDarkMode,
     });
-    return await sendEmailValidCode(email, userId);
+    return await sendEmailValidCode(email, userInfo.userId);
   };
 
   //이메일 인증 버튼 누르면 실행되는 함수
@@ -77,7 +79,7 @@ const RegisterCompany = () => {
       return;
     }
     setCodeChecked(true);
-    const response = await getEmailValid(userId, code);
+    const response = await getEmailValid(userInfo.userId, code);
     if (response.status == 200) {
       setIsCodeSame(true);
     } else {
@@ -101,35 +103,37 @@ const RegisterCompany = () => {
       });
       return false;
     }
+    return true;
   };
 
-  const handleSubmitCompanyInfo = (data: CompanyInfoStateType) => {
+  const handleCompleteSignupProcess = async (data: CompanyInfoStateType) => {
     if (!handleCheckEmailCertification()) {
       return;
     }
+
     const formData = new FormData();
-    formData.append("userId", userId);
+    formData.append("userId", userInfo.userId);
     formData.append("companyName", data.companyName);
     formData.append("companyEmail", data.companyEmail);
     formData.append("department", data.department[0]);
     formData.append("businessCard", data.businessCard[0]);
 
-    registerCompanyInfo(formData, false)
-      .then(() => {
-        showToast({
-          message: "회사 정보 등록 완료! 다시 로그인 해주세요!",
-          type: "success",
-          isDarkMode: false,
-        });
-        navigate("/login");
-      })
-      .catch(() => {
-        showToast({
-          message: "회사 정보 등록에 실패했습니다.",
-          type: "error",
-          isDarkMode: false,
-        });
+    try {
+      await registerUserInfo(userInfo);
+      await registerCompanyInfo(formData, false);
+      showToast({
+        message: "회원 가입 완료! 다시 로그인 해주세요!",
+        type: "success",
+        isDarkMode: false,
       });
+      navigate("/login");
+    } catch (error) {
+      showToast({
+        message: "회원 가입에 실패했습니다.",
+        type: "error",
+        isDarkMode: false,
+      });
+    }
   };
 
   return (
@@ -160,7 +164,7 @@ const RegisterCompany = () => {
         <StyleDivider />
       </StyleRegisterHeader>
       <Spacing size={13} />
-      <form onSubmit={companyInfoForm.handleSubmit(handleSubmitCompanyInfo)}>
+      <form onSubmit={companyInfoForm.handleSubmit(handleCompleteSignupProcess)}>
         <StyleDataWrapper>
           <FlexBox
             gap={16}

--- a/src/pages/register/RegisterUser.tsx
+++ b/src/pages/register/RegisterUser.tsx
@@ -6,8 +6,6 @@ import type { UserInfoStateType } from "@/schemas/userInfo";
 import { UserInfoSchema } from "@/schemas/userInfo";
 import styled from "@emotion/styled";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation } from "@tanstack/react-query";
-import { axiosAPI } from "@/apis/axios";
 import getNicknameValid from "@/apis/register/getNicknameValid.ts";
 import AlertText from "@/components/common/AlertText";
 import NormalButton from "@/components/common/Buttons/NormalButton";
@@ -81,35 +79,16 @@ const RegisterUser = () => {
     }
   };
   const submitUserProfileData = (data: UserInfoStateType) => {
-    console.log(data);
     if (formValidation(data.nickname)) {
-      const body = {
+      const userInfo = {
         userId: userId,
         nickname: data.nickname,
         keywords: data.interest,
       };
-      registerMutation.mutate(body);
+      navigate("/register/company", { state: { userInfo } });
     }
   };
-  const registerPost = async (body: object) => {
-    return await axiosAPI.post("/v1/users/sign-up", body);
-  };
 
-  const registerMutation = useMutation({
-    mutationFn: (body: object) => registerPost(body),
-    onSuccess: () => {
-      showToast({
-        message: "닉네임, 관심사 정보 등록을 완료했습니다!",
-        type: "success",
-        isDarkMode,
-      });
-
-      navigate("/register/company", { state: { userId: userId } });
-    },
-    onError: (err) => {
-      console.log(err);
-    },
-  });
   return (
     <StyleRegisterWrapper>
       <StyleRegisterHeader>


### PR DESCRIPTION
## 이슈번호
관련 이슈: #238 

## 작업 내용 설명

- 이제 회원 정보 등록 페이지에서 회원 정보 데이터를 회사 정보 등록 페이지로 넘깁니다.
- 회사 정보 등록 데이터 검증이 끝났을 때 두 데이터를 순차적으로 전송합니다(유저 -> 회사)

## 리뷰어에게 한마디


