### PR TITLE
Fix: 등록 / 수정 페이지의 버튼 onClick 핸들러 함수 개선 및 zod 스키마 유효성 검증 로직 수정

### DIFF
--- a/src/pages/profile/ProfileCompanyEdit.tsx
+++ b/src/pages/profile/ProfileCompanyEdit.tsx
@@ -163,7 +163,10 @@ const ProfileCompanyEdit = () => {
               />
               <NormalButton
                 normalButtonType={"email-certify"}
-                onClick={() => handleVerifyEmail(companyInfoForm.getValues("companyEmail"))}
+                onClick={(event) => {
+                  event.preventDefault();
+                  handleVerifyEmail(companyInfoForm.getValues("companyEmail"));
+                }}
               >
                 {"이메일 인증"}
               </NormalButton>
@@ -193,7 +196,10 @@ const ProfileCompanyEdit = () => {
                 {...companyInfoForm.register("certCode")}
               />
               <StyleVerificationEmailButton
-                onClick={() => handleVerifyCode(companyInfoForm.getValues("certCode"))}
+                onClick={(event) => {
+                  event.preventDefault();
+                  handleVerifyCode(companyInfoForm.getValues("certCode"));
+                }}
               >
                 {"확인"}
               </StyleVerificationEmailButton>

--- a/src/pages/register/RegisterCompany.tsx
+++ b/src/pages/register/RegisterCompany.tsx
@@ -198,7 +198,10 @@ const RegisterCompany = () => {
               />
               <NormalButton
                 normalButtonType={"email-certify"}
-                onClick={() => handleEmailCertification(companyInfoForm.getValues("companyEmail"))}
+                onClick={(event) => {
+                  event.preventDefault();
+                  handleEmailCertification(companyInfoForm.getValues("companyEmail"));
+                }}
               >
                 {"이메일 인증"}
               </NormalButton>
@@ -229,7 +232,10 @@ const RegisterCompany = () => {
               {...companyInfoForm.register("certCode")}
             />
             <StyleVerificationEmailButton
-              onClick={() => checkCodeValid(companyInfoForm.getValues("certCode"))}
+              onClick={(event) => {
+                event.preventDefault();
+                checkCodeValid(companyInfoForm.getValues("certCode"));
+              }}
             >
               {"확인"}
             </StyleVerificationEmailButton>

--- a/src/pages/register/RegisterUser.tsx
+++ b/src/pages/register/RegisterUser.tsx
@@ -120,7 +120,10 @@ const RegisterUser = () => {
           />
           <NormalButton
             normalButtonType={"nickname-duplicate"}
-            onClick={() => doubleCheckNickName(userInfoForm.getValues("nickname"))}
+            onClick={(event) => {
+              event.preventDefault();
+              doubleCheckNickName(userInfoForm.getValues("nickname"));
+            }}
           >
             {"중복확인"}
           </NormalButton>

--- a/src/schemas/companyInfo.ts
+++ b/src/schemas/companyInfo.ts
@@ -8,7 +8,7 @@ export const CompanyInfoSchema = z.object({
     .string()
     .min(1, { message: "회사 이메일을 입력해주세요." })
     .email({ message: "이메일 형식이어야 합니다." }),
-  department: z.array(z.string().min(1, { message: "부서를 선택해주세요." })),
+  department: z.array(z.string()).min(1, { message: "부서를 선택해주세요." }),
   certCode: z.string().min(1, { message: "인증 코드를 입력해주세요." }),
   businessCard: z
     .any()

--- a/src/schemas/userInfo.ts
+++ b/src/schemas/userInfo.ts
@@ -2,7 +2,7 @@ import * as z from "zod";
 
 export const UserInfoSchema = z.object({
   nickname: z.string().min(1, { message: "닉네임을 입력해주세요." }),
-  interest: z.array(z.string().min(1, { message: "관심사를 선택해주세요." })),
+  interest: z.array(z.string()).min(1, { message: "관심사를 선택해주세요." }),
 });
 
 export type UserInfoStateType = z.infer<typeof UserInfoSchema>;


### PR DESCRIPTION
## 이슈번호

close: #268

## 작업 내용 설명

<!-- 스크린샷 및 작업내용을 적어주세요 -->
- 폼을 포함한 페이지의 버튼이 있는 경우 onClick 핸들러 함수에 `event.preventDefault()`를 추가하여 onSubmit이 트리거되지 않도록 했습니다.
- zod 스키마 필드 데이터 유효성 검증 로직 중 배열의 길이를 검사해야하는데 문자열의 길이를 검사하고 있던 부분을 수정했습니다.

## 리뷰어에게 한마디

<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->
