### PR TITLE
Bug: 닉네임 5글자 넘어가면 레이아웃 깨지는 현상 외 1건 수정

### DIFF
--- a/src/apis/profile/type.ts
+++ b/src/apis/profile/type.ts
@@ -9,4 +9,5 @@ export type MyProfileData = {
   companyName: string;
   department: string;
   interests: string[];
+  oAuthProvider: string;
 };

--- a/src/components/common/AppHeader/index.tsx
+++ b/src/components/common/AppHeader/index.tsx
@@ -122,7 +122,7 @@ const AppHeader = ({ isAuth, isDarkMode, height, toggleDarkMode }: AppHeaderProp
       <FlexBox align={"flex-end"}>
         <StyledAppHeaderLargeText
           isDarkMode={isDarkMode}
-          font={"Body_22"}
+          font={"Body_20"}
           fontWeight={600}
           letterSpacing={-0.5}
           style={{
@@ -132,7 +132,7 @@ const AppHeader = ({ isAuth, isDarkMode, height, toggleDarkMode }: AppHeaderProp
             overflow: "hidden",
             whiteSpace: "nowrap",
             wordBreak: "break-all",
-            width: "25%",
+            maxWidth: "27%",
           }}
         >
           {nickname}

--- a/src/components/common/AppHeader/index.tsx
+++ b/src/components/common/AppHeader/index.tsx
@@ -122,19 +122,24 @@ const AppHeader = ({ isAuth, isDarkMode, height, toggleDarkMode }: AppHeaderProp
       <FlexBox align={"flex-end"}>
         <StyledAppHeaderLargeText
           isDarkMode={isDarkMode}
-          font={"Body_24"}
+          font={"Body_22"}
           fontWeight={600}
           letterSpacing={-0.5}
           style={{
             color: isDarkMode ? palette.DARK_WHITE : palette.WHITE,
             marginRight: 5,
+            textOverflow: "ellipsis",
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+            wordBreak: "break-all",
+            width: "25%",
           }}
         >
           {nickname}
         </StyledAppHeaderLargeText>
         <StyledAppHeaderSmallText
           isDarkMode={isDarkMode}
-          font={"Body_18"}
+          font={"Body_16"}
           fontWeight={600}
           letterSpacing={-0.5}
           style={{

--- a/src/components/common/AppHeader/index.tsx
+++ b/src/components/common/AppHeader/index.tsx
@@ -2,6 +2,8 @@ import { BiSolidMoon } from "react-icons/bi";
 import { RiSunFill } from "react-icons/ri";
 import { useNavigate } from "react-router-dom";
 import styled from "@emotion/styled";
+import { useQuery } from "@tanstack/react-query";
+import getMyProfileData from "@/apis/profile/getMyProfileData.ts";
 import Avatar from "@/components/common/Avatar";
 import { FlexBox } from "@/components/common/Flexbox";
 import { Text } from "@/components/common/Text";
@@ -41,32 +43,41 @@ const StyledAppHeaderSmallText = styled(Text)<Pick<AppHeaderProps, "isDarkMode">
 `;
 
 type AppHeaderProps = {
-  nickname: string;
-  profileImageUrl: string;
+  isAuth: boolean;
   isDarkMode: boolean;
   height?: string;
   toggleDarkMode: () => void;
 };
 
 /**
- * @param nickname - 유저 닉네임
- * @param profileImageUrl - 유저 프로필 이미지 URL
+ * @param isAuth - 인증 여부
  * @param isDarkMode - 다크모드 여부
  * @param height - 컴포넌트 높이
  * @param toggleDarkMode - 다크모드 토글 함수
  */
 
-const AppHeader = ({
-  nickname,
-  profileImageUrl,
-  isDarkMode,
-  height,
-  toggleDarkMode,
-}: AppHeaderProps) => {
+const AppHeader = ({ isAuth, isDarkMode, height, toggleDarkMode }: AppHeaderProps) => {
   const navigate = useNavigate();
   const moveFromAppHeader = (path: string) => {
     navigate(`/${path}`);
   };
+
+  const { data, isError, isPending } = useQuery({
+    queryKey: ["myProfileData"],
+    queryFn: getMyProfileData,
+    staleTime: Infinity,
+    enabled: isAuth,
+  });
+
+  if (isPending) {
+    return <div>{"로딩중..."}</div>; // TODO: 로딩 컴포넌트로 대체
+  }
+
+  if (isError) {
+    return <div>{"에러가 발생했습니다."}</div>;
+  }
+
+  const { nickname, profileImageUrl } = data;
 
   return (
     <StyleAppHeader height={height}>

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Card from "@/pages/home/components/Card.tsx";
 import AppHeader from "@/components/common/AppHeader";
@@ -13,8 +13,6 @@ import useAuthStore from "@/store/AuthStore.tsx";
 import useThemeStore from "@/store/ThemeStore";
 
 const Home = () => {
-  const [nickname, setNickname] = useState("");
-  const [profileImageUrl, setProfileImageUrl] = useState("");
   const isDarkMode = useThemeStore((state) => state.isDarkMode);
   const toggleDarkMode = useThemeStore((state) => state.toggleDarkMode);
   const { authTokens } = useAuthStore();
@@ -30,17 +28,12 @@ const Home = () => {
       });
       navigate("/login");
     }
-    if (authTokens) {
-      setNickname(localStorage.getItem("nickname") || "");
-      setProfileImageUrl(localStorage.getItem("profileImageUrl") || "");
-    }
-  }, [nickname, profileImageUrl]);
+  }, []);
 
   return (
     <GradationBackground isDarkMode={isDarkMode}>
       <AppHeader
-        nickname={localStorage.getItem("nickname") || ""}
-        profileImageUrl={localStorage.getItem("profileImageUrl") || ""}
+        isAuth={!!authTokens?.accessToken}
         isDarkMode={isDarkMode}
         toggleDarkMode={toggleDarkMode}
       />

--- a/src/pages/profile/ProfileEdit.tsx
+++ b/src/pages/profile/ProfileEdit.tsx
@@ -163,7 +163,7 @@ const ProfileEdit = () => {
             <FlexBox gap={10}>
               <RegisterInput
                 width={240}
-                placeholder={"닉네임"}
+                placeholder={"닉네임 (10자 제한)"}
                 {...userInfoForm.register("nickname")}
               />
               <NormalButton

--- a/src/pages/profile/ProfileEdit.tsx
+++ b/src/pages/profile/ProfileEdit.tsx
@@ -5,8 +5,7 @@ import type { UserInfoStateType } from "@/schemas/userInfo";
 import { UserInfoSchema } from "@/schemas/userInfo";
 import styled from "@emotion/styled";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useQuery } from "@tanstack/react-query";
-import getMyProfileData from "@/apis/profile/getMyProfileData.ts";
+import { useQueryClient } from "@tanstack/react-query";
 import postMyProfileImage from "@/apis/profile/postMyProfileImage.ts";
 import updateMyProfile from "@/apis/profile/updateMyProfile.ts";
 import getNicknameValid from "@/apis/register/getNicknameValid.ts";
@@ -31,24 +30,15 @@ const ProfileEdit = () => {
   const isDarkMode = useThemeStore((state) => state.isDarkMode);
 
   const [nicknameDuplicated, setNicknameDuplicated] = useState<null | boolean>(null);
-  const [imgSrc, setImgSrc] = useState("");
+  const [imgSrc, setImgSrc] = useState("default_image_url");
   const { showToast } = useToast();
   const navigate = useNavigate();
   const userInfoForm = useForm<UserInfoStateType>({
     resolver: zodResolver(UserInfoSchema),
   });
+  const queryClient = useQueryClient();
 
-  const { data, error, isLoading, refetch } = useQuery({
-    queryKey: ["myProfileData"],
-    queryFn: getMyProfileData,
-  });
-
-  if (isLoading) {
-    return <div>{"로딩중..."}</div>;
-  }
-  if (error) {
-    return <div>{"에러가 발생했습니다."}</div>;
-  }
+  // const data = queryClient.getQueryData(["myProfileData"]);
 
   const checkNicknameDuplicated = (nickname: string) => {
     if (nickname.length === 0) {
@@ -87,7 +77,7 @@ const ProfileEdit = () => {
             type: "success",
             isDarkMode,
           });
-          refetch();
+          queryClient.invalidateQueries({ queryKey: ["myProfileData"] });
         })
         .catch(() => {
           showToast({
@@ -120,6 +110,7 @@ const ProfileEdit = () => {
           type: "success",
           isDarkMode,
         });
+        queryClient.invalidateQueries({ queryKey: ["myProfileData"] });
         navigate("/profile");
       })
       .catch(() => {
@@ -154,7 +145,7 @@ const ProfileEdit = () => {
           <Avatar
             width={80}
             height={80}
-            imgUrl={data?.profileImageUrl ?? imgSrc}
+            imgUrl={imgSrc}
           />
           <Spacing size={20} />
           <label htmlFor={"profile-image-upload"}>

--- a/src/pages/register/RegisterUser.tsx
+++ b/src/pages/register/RegisterUser.tsx
@@ -115,7 +115,7 @@ const RegisterUser = () => {
         <FlexBox gap={16}>
           <RegisterInput
             width={260}
-            placeholder={"닉네임"}
+            placeholder={"닉네임 (10자 제한)"}
             {...userInfoForm.register("nickname")}
           />
           <NormalButton

--- a/src/schemas/userInfo.ts
+++ b/src/schemas/userInfo.ts
@@ -1,7 +1,10 @@
 import * as z from "zod";
 
 export const UserInfoSchema = z.object({
-  nickname: z.string().min(1, { message: "닉네임을 입력해주세요." }),
+  nickname: z
+    .string()
+    .min(1, { message: "닉네임을 입력해주세요." })
+    .max(10, { message: "닉네임은 10자 이내로 입력해주세요." }),
   interest: z.array(z.string()).min(1, { message: "관심사를 선택해주세요." }),
 });
 


### PR DESCRIPTION
## 이슈번호

<!-- - close 뒤에 이슈 달아주기 -->
close: #271 

## 작업 내용 설명

<!-- 스크린샷 및 작업내용을 적어주세요 -->
- AppHeader에서 닉네임과 고정 문구를 관리하고 있어서 스타일에 변화를 주었습니다!
    - 한줄 표기를 위해 폰트 크기와 닉네임 컨테이너의 너비를 조정하였고, text-ellipsis(말줄임 효과) 스타일을 추가했습니다!
- 닉네임을 10자로 제한하기 위해 zod 스키마에 검증 로직을 추가하였고, 관련 Input의 placeholder 내용 또한 수정하였습니다!
- 로그인 후 유저 프로필 데이터를 여러 곳에서 무분별하게 fetching하고 있어서 AppHeader에서 최초 Fetching, 프로필 페이지는 캐싱된 데이터를 사용하도록 변경하였고, 프로필 수정 시 캐싱된 데이터를 무효화하도록 변경하였습니다!

## 리뷰어에게 한마디

<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->
