### PR TITLE
Fix: 인증 관련 정보 정리 외 자잘한 수정

### DIFF
--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -1,5 +1,14 @@
 import axios from "axios";
-import useAuthStore from "@/store/AuthStore.tsx";
+
+type AuthStoreState = {
+  authTokens: {
+    accessToken: string;
+    refreshToken: string;
+  };
+  userId: number;
+};
+
+const { state }: { state: AuthStoreState } = JSON.parse(localStorage.getItem("auth-store") || "{}");
 
 export const axiosAPI = axios.create({
   baseURL:
@@ -11,7 +20,7 @@ export const axiosAPI = axios.create({
 // Add a request interceptor
 axiosAPI.interceptors.request.use(
   function (config) {
-    config.headers["Authorization"] = `${useAuthStore().authTokens?.accessToken}`;
+    config.headers["Authorization"] = `${state.authTokens.accessToken}`;
 
     return config;
   },

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -1,6 +1,5 @@
 import axios from "axios";
-
-// import useAuthStore from '@/store/AuthStore'
+import useAuthStore from "@/store/AuthStore.tsx";
 
 export const axiosAPI = axios.create({
   baseURL:
@@ -12,15 +11,11 @@ export const axiosAPI = axios.create({
 // Add a request interceptor
 axiosAPI.interceptors.request.use(
   function (config) {
-    // 요청 바로 직전
-    // axios 설정값에 대해 작성합니다.
-
-    config.headers["Authorization"] = `${localStorage.getItem("jwt")}`;
+    config.headers["Authorization"] = `${useAuthStore().authTokens?.accessToken}`;
 
     return config;
   },
   function (error) {
-    // 요청 에러 처리를 작성합니다.
     return Promise.reject(error);
   },
 );
@@ -48,20 +43,3 @@ axiosAPI.interceptors.response.use(
     return Promise.reject(error);
   },
 );
-
-// Response interceptor
-// function interceptorResponseFulfilled(res: AxiosResponse) {
-//   if (200 <= res.status && res.status < 300) {
-//     return res
-//   }
-
-//   return Promise.reject(res)
-// }
-
-// function interceptorResponseRejected(error: AxiosError<ApiErrorScheme>) {
-//   if (error.response?.data?.message) {
-//     return Promise.reject(new ApiException(error.response.data, error.response.status))
-//   }
-// }
-
-// axiosAPI.interceptors.response.use(interceptorResponseFulfilled, interceptorResponseRejected)

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -15,40 +15,9 @@ export const axiosAPI = axios.create({
     process.env.NODE_ENV === "development"
       ? "http://localhost:5173"
       : import.meta.env.VITE_BASE_URL,
+  headers: {
+    Authorization: `${state.authTokens.accessToken}`,
+  },
 });
 
-// Add a request interceptor
-axiosAPI.interceptors.request.use(
-  function (config) {
-    config.headers["Authorization"] = `${state.authTokens.accessToken}`;
-
-    return config;
-  },
-  function (error) {
-    return Promise.reject(error);
-  },
-);
-
-// Add a response interceptor
-axiosAPI.interceptors.response.use(
-  function (response) {
-    /*
-        http status가 200인 경우
-        응답 바로 직전에 대해 작성합니다.
-        .then() 으로 이어집니다.
-    */
-    return response;
-  },
-
-  function (error) {
-    /*
-        http status가 200이 아닌 경우
-        응답 에러 처리를 작성합니다.
-        .catch() 으로 이어집니다.
-    */
-    if (error.response && error.response.status === 401) {
-      return new Promise(() => {}); //이행되지 않은 Promise를 반환하여 Promise Chaining 끊어주기
-    }
-    return Promise.reject(error);
-  },
-);
+// TODO: axiosAPI.interceptors.response.use()를 사용하여 refreshToken이 만료되었을 때, accessToken을 재발급 받는 로직을 구현해야 합니다.

--- a/src/apis/profile/getMyProfileData.ts
+++ b/src/apis/profile/getMyProfileData.ts
@@ -4,9 +4,6 @@ import type { MyProfileData } from "@/apis/profile/type.ts";
 const getMyProfileData = async () => {
   try {
     const res = await axiosAPI.get<MyProfileData>("/v1/users/me");
-    if (res.status !== 200) {
-      throw new Error("get my profile data failed!");
-    }
     return res.data;
   } catch (err) {
     console.log(err);

--- a/src/apis/queryClient.ts
+++ b/src/apis/queryClient.ts
@@ -8,6 +8,7 @@ export const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false,
       refetchOnMount: false,
+      retry: 1,
     },
   },
   queryCache: new QueryCache({

--- a/src/components/common/MultiSelector/index.tsx
+++ b/src/components/common/MultiSelector/index.tsx
@@ -6,6 +6,7 @@ type MultiSelectorProps = {
   isDarkMode: boolean;
   itemList: string[];
   maxCount: number;
+  defaultSelectedList?: string[];
   onValueChange?: (value: string[]) => void;
 };
 
@@ -13,10 +14,18 @@ const MultiSelector = ({
   isDarkMode,
   itemList,
   maxCount = 0,
+  defaultSelectedList,
   onValueChange,
 }: MultiSelectorProps) => {
   const [selectedList, setSelectedList] = useState<string[]>([]);
   const [selectedCount, setSelectedCount] = useState(0);
+
+  useEffect(() => {
+    if (defaultSelectedList) {
+      setSelectedList(defaultSelectedList);
+      setSelectedCount(defaultSelectedList.length);
+    }
+  }, []);
 
   useEffect(() => {
     onValueChange?.(selectedList);

--- a/src/libs/react-query/options/getMyProfileData.ts
+++ b/src/libs/react-query/options/getMyProfileData.ts
@@ -1,0 +1,6 @@
+import getMyProfileData from "@/apis/profile/getMyProfileData.ts";
+
+export const getMyProfileDataOptions = {
+  queryKey: ["myProfileData"],
+  queryFn: getMyProfileData,
+};

--- a/src/pages/chatting/Chatting.tsx
+++ b/src/pages/chatting/Chatting.tsx
@@ -17,6 +17,7 @@ import TextArea from "@/components/common/TextArea";
 import { useModal } from "@/hooks/useModal";
 import useToast from "@/hooks/useToast";
 import { palette } from "@/styles/palette";
+import useAuthStore from "@/store/AuthStore.tsx";
 import useBottomSheetStore from "@/store/BottomSheetStore";
 import ExitIcon from "@/assets/icons/ExitIcon";
 import Send from "@/assets/icons/Send.svg";
@@ -63,7 +64,7 @@ const Chatting = () => {
         console.log(response);
       },
       connectHeaders: {
-        Authorization: `${localStorage.getItem("jwt")}`,
+        Authorization: `${useAuthStore().authTokens?.accessToken}`,
       },
     });
     client.current.activate();
@@ -138,7 +139,7 @@ const Chatting = () => {
           content: message,
         }),
         headers: {
-          Authorization: `${localStorage.getItem("jwt")}`,
+          Authorization: `${useAuthStore().authTokens?.accessToken}`,
         },
       });
     }

--- a/src/pages/chatting/Chatting.tsx
+++ b/src/pages/chatting/Chatting.tsx
@@ -25,6 +25,7 @@ import Send from "@/assets/icons/Send.svg";
 const Chatting = () => {
   const { openModal } = useModal();
   const navigate = useNavigate();
+  const authStore = useAuthStore();
   const { chatroomId } = useLocation().state;
   const { chatroomName } = useLocation().state;
   const [messages, setMessages] = useState<Messages[] | []>([] as Messages[]);
@@ -64,7 +65,7 @@ const Chatting = () => {
         console.log(response);
       },
       connectHeaders: {
-        Authorization: `${useAuthStore().authTokens?.accessToken}`,
+        Authorization: `${authStore.authTokens?.accessToken}`,
       },
     });
     client.current.activate();
@@ -139,7 +140,7 @@ const Chatting = () => {
           content: message,
         }),
         headers: {
-          Authorization: `${useAuthStore().authTokens?.accessToken}`,
+          Authorization: `${authStore.authTokens?.accessToken}`,
         },
       });
     }

--- a/src/pages/chatting/components/messageArea/index.tsx
+++ b/src/pages/chatting/components/messageArea/index.tsx
@@ -1,5 +1,7 @@
 import styled from "@emotion/styled";
+import { useQueryClient } from "@tanstack/react-query";
 import type { Messages } from "@/apis/chatting/chattingType";
+import type { MyProfileData } from "@/apis/profile/type.ts";
 import ChatBubbleListLow from "@/pages/chatting/components/chatBubbleListLow";
 import { FlexBox } from "@/components/common/Flexbox";
 import Spacing from "@/components/common/Spacing";
@@ -10,6 +12,8 @@ interface MessageProps {
 }
 
 const MessageArea = ({ messageData }: MessageProps) => {
+  const queryClient = useQueryClient();
+  const nickname = queryClient.getQueryData<MyProfileData>(["myProfileData"])?.nickname;
   return (
     <>
       <FlexBox
@@ -21,7 +25,7 @@ const MessageArea = ({ messageData }: MessageProps) => {
         {messageData &&
           messageData.map((message, i) =>
             //로그인 성공 후 nickname 전역에 저장하면 내 닉네임 불러오기
-            message.nickname == localStorage.getItem("nickname") ? (
+            message.nickname == nickname ? (
               <StyleChattingBubbleWrapper
                 key={i}
                 isMyChat={true}

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -31,6 +31,7 @@ const Login = () => {
         <Spacing size={50} />
         <img
           src={CafeSvg}
+          alt={"coffee-meet-logo"}
           width={250}
         />
         <Spacing

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { KakaoButton, NaverButton } from "@/components/common/Buttons/IconButton";
+import { KakaoButton } from "@/components/common/Buttons/IconButton";
 import NormalButton from "@/components/common/Buttons/NormalButton";
 import Spacing from "@/components/common/Spacing";
 import { Text } from "@/components/common/Text";
@@ -91,19 +91,20 @@ const Login = () => {
           `}
         />
         <StyledOauthWrapper>
-          <NaverButton
-            moveToOAuthProvider={() => {
-              handleMoveToAuthProvider("NAVER");
-            }}
-          />
-          <Spacing
-            size={16}
-            css={css`
-              @media (max-width: 375px) {
-                height: ${16 * 0.75}px;
-              }
-            `}
-          />
+          {/* 네이버 로그인 승인 될 때까지 버튼 은닉 */}
+          {/*<NaverButton*/}
+          {/*  moveToOAuthProvider={() => {*/}
+          {/*    handleMoveToAuthProvider("NAVER");*/}
+          {/*  }}*/}
+          {/*/>*/}
+          {/*<Spacing*/}
+          {/*  size={16}*/}
+          {/*  css={css`*/}
+          {/*    @media (max-width: 375px) {*/}
+          {/*      height: ${16 * 0.75}px;*/}
+          {/*    }*/}
+          {/*  `}*/}
+          {/*/>*/}
           <KakaoButton
             moveToOAuthProvider={() => {
               handleMoveToAuthProvider("KAKAO");

--- a/src/pages/loginPending/LoginPending.tsx
+++ b/src/pages/loginPending/LoginPending.tsx
@@ -21,6 +21,7 @@ const LoginPending = () => {
   const [searchParams] = useSearchParams();
   const authCode = searchParams.get("code");
   const setToken = useAuthStore((state) => state.setAuthTokens);
+  const setUserId = useAuthStore((state) => state.setUserId);
   const provider = useAuthStore((state) => state.provider);
 
   const { showToast } = useToast();
@@ -28,26 +29,19 @@ const LoginPending = () => {
     await axiosAPI
       .get<LoginResponse>(`/v1/users/login/${provider}?authCode=${authCode}`)
       .then((res) => {
-        const { userId, accessToken, refreshToken, isRegistered, nickname, profileImageUrl } =
-          res.data;
+        const { userId, accessToken, refreshToken, isRegistered } = res.data;
 
         if (!isRegistered) {
           navigate("/register/user", { state: { userId: userId } });
         }
 
         if (isRegistered) {
-          localStorage.setItem("jwt", accessToken);
-          // TODO: 아래 3개의 정보는 추후 AuthStore에서 관리?
-          localStorage.setItem("userId", userId.toString());
-          localStorage.setItem("nickname", nickname);
-          localStorage.setItem("profileImageUrl", profileImageUrl);
           setToken({
             accessToken: accessToken,
             refreshToken: refreshToken,
           });
-          navigate("/", {
-            state: { userId: userId, nickname: nickname, profileImageUrl: profileImageUrl },
-          });
+          setUserId(userId);
+          navigate("/", { replace: true });
         }
       })
       .catch((error) => {

--- a/src/pages/profile/ProfileCompanyEdit.tsx
+++ b/src/pages/profile/ProfileCompanyEdit.tsx
@@ -22,13 +22,14 @@ import RegisterInput from "@/components/common/RegisterInput";
 import Spacing from "@/components/common/Spacing";
 import useToast from "@/hooks/useToast.tsx";
 import { palette } from "@/styles/palette.ts";
+import useAuthStore from "@/store/AuthStore.tsx";
 import useThemeStore from "@/store/ThemeStore.tsx";
 import { JobList } from "@/constants/index.ts";
 
 const ProfileCompanyEdit = () => {
   const { isDarkMode } = useThemeStore();
   const navigate = useNavigate();
-  const userId = localStorage.getItem("userId");
+  const userId = useAuthStore((state) => state.userId);
   const [isCodeSame, setIsCodeSame] = useState<null | boolean>(null);
   const [codeChecked, setCodeChecked] = useState<null | boolean>(null);
   const [uploadedURL, setUploadedURL] = useState("");
@@ -49,7 +50,7 @@ const ProfileCompanyEdit = () => {
       return;
     }
     showToast({ message: "인증코드가 전송되었습니다! ", type: "success", isDarkMode });
-    return await sendEmailValidCode(email, userId);
+    return await sendEmailValidCode(email, userId.toString());
   };
 
   const handleVerifyCode = async (code: string) => {
@@ -62,7 +63,7 @@ const ProfileCompanyEdit = () => {
       return;
     }
     setCodeChecked(true);
-    const response = await getEmailValid(userId, code);
+    const response = await getEmailValid(userId.toString(), code);
     if (response.status == 200) {
       setIsCodeSame(true);
     } else {

--- a/src/pages/profile/ProfileCompanyEdit.tsx
+++ b/src/pages/profile/ProfileCompanyEdit.tsx
@@ -5,6 +5,8 @@ import type { CompanyInfoStateType } from "@/schemas/companyInfo.ts";
 import { CompanyInfoSchema } from "@/schemas/companyInfo.ts";
 import styled from "@emotion/styled";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
+import type { MyProfileData } from "@/apis/profile/type.ts";
 import getEmailValid from "@/apis/register/getEmailValid.ts";
 import registerCompanyInfo from "@/apis/register/registerCompanyInfo.ts";
 import sendEmailValidCode from "@/apis/register/sendEmailValidCode.ts";
@@ -39,6 +41,9 @@ const ProfileCompanyEdit = () => {
     resolver: zodResolver(CompanyInfoSchema),
   });
   const cardPreview = companyInfoForm.watch("businessCard");
+
+  const queryClient = useQueryClient();
+  const data = queryClient.getQueryData<MyProfileData>(["myProfileData"]);
 
   const handleVerifyEmail = async (email: string) => {
     if (!email) {
@@ -140,6 +145,7 @@ const ProfileCompanyEdit = () => {
             <RegisterInput
               width={343}
               placeholder={"회사 이름"}
+              defaultValue={data?.companyName}
               {...companyInfoForm.register("companyName")}
             />
             <div>
@@ -240,6 +246,7 @@ const ProfileCompanyEdit = () => {
                     isDarkMode={isDarkMode}
                     itemList={JobList}
                     maxCount={1}
+                    defaultSelectedList={[data?.department?.toString() ?? ""]}
                     onValueChange={field.onChange}
                   />
                 )}

--- a/src/pages/profile/ProfileDefault.tsx
+++ b/src/pages/profile/ProfileDefault.tsx
@@ -3,10 +3,10 @@ import { BiBuildings, BiChevronRight, BiPencil } from "react-icons/bi";
 import { MdOutlineRecordVoiceOver } from "react-icons/md";
 import { PiIdentificationCardBold } from "react-icons/pi";
 import { useNavigate } from "react-router-dom";
+import { getMyProfileDataOptions } from "@/libs/react-query/options/getMyProfileData.ts";
 import styled from "@emotion/styled";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { axiosAPI } from "@/apis/axios";
-import type { MyProfileData } from "@/apis/profile/type.ts";
 import Avatar from "@/components/common/Avatar";
 import BackChevron from "@/components/common/BackChevron";
 import { InterestButton } from "@/components/common/Buttons/IconButton";
@@ -32,18 +32,19 @@ const ProfileDefault = () => {
   const isDarkMode = useThemeStore((store) => store.isDarkMode);
   const { openModal } = useModal();
   const { showToast } = useToast();
-  const queryClient = useQueryClient();
 
-  const data = queryClient.getQueryData<MyProfileData>(["myProfileData"]);
+  const { data, isError, error } = useQuery({
+    ...getMyProfileDataOptions,
+  });
 
-  if (!data) {
+  if (isError) {
+    console.log(error);
     showToast({
-      message: "필요한 정보를 불러오지 못했습니다! 다시 로그인해주세요!",
-      type: "warning",
+      message: "프로필 정보를 불러오는데 실패했습니다.",
+      type: "error",
       isDarkMode,
     });
     navigate("/login");
-    return null;
   }
 
   const handleLogout = () => {
@@ -102,7 +103,7 @@ const ProfileDefault = () => {
             <Avatar
               width={49}
               height={49}
-              imgUrl={data.profileImageUrl}
+              imgUrl={data?.profileImageUrl || "default_image_url"}
             />
             <StyledProfilePrimaryInfoTextWrapper>
               <TextWrapper
@@ -118,7 +119,7 @@ const ProfileDefault = () => {
                   fontWeight={600}
                   letterSpacing={-1}
                 >
-                  {data.nickname}
+                  {data?.nickname}
                 </Text>
                 <Divider
                   width={"2px"}
@@ -131,7 +132,7 @@ const ProfileDefault = () => {
                   fontWeight={400}
                   letterSpacing={-1}
                 >
-                  {data.companyName}
+                  {data?.companyName}
                 </Text>
               </TextWrapper>
               <TextWrapper
@@ -146,7 +147,7 @@ const ProfileDefault = () => {
                   fontWeight={600}
                   letterSpacing={-1}
                 >
-                  {data.department}
+                  {data?.department}
                 </Text>
               </TextWrapper>
             </StyledProfilePrimaryInfoTextWrapper>
@@ -164,7 +165,7 @@ const ProfileDefault = () => {
         <Spacing size={17.5} />
         <InterestButton
           nickName={"나"}
-          interests={data.interests}
+          interests={data?.interests || []}
           isDarkMode={isDarkMode}
         />
         <Spacing size={28.5} />
@@ -232,7 +233,7 @@ const ProfileDefault = () => {
             title={"소셜 로그인 계정"}
             isDarkMode={isDarkMode}
             additionalContent={
-              data.oAuthProvider === "NAVER" ? (
+              data?.oAuthProvider === "NAVER" ? (
                 <NaverIcon
                   width={20}
                   height={20}

--- a/src/pages/profile/ProfileDefault.tsx
+++ b/src/pages/profile/ProfileDefault.tsx
@@ -35,6 +35,7 @@ const ProfileDefault = () => {
 
   const { data, isError, error } = useQuery({
     ...getMyProfileDataOptions,
+    staleTime: Infinity,
   });
 
   if (isError) {
@@ -44,6 +45,7 @@ const ProfileDefault = () => {
       type: "error",
       isDarkMode,
     });
+    useAuthStore.persist.clearStorage();
     navigate("/login");
   }
 

--- a/src/pages/profile/ProfileDefault.tsx
+++ b/src/pages/profile/ProfileDefault.tsx
@@ -54,10 +54,6 @@ const ProfileDefault = () => {
         await axiosAPI
           .post("/v1/auth/logout")
           .then(() => {
-            localStorage.setItem("jwt", "");
-            localStorage.removeItem("userId");
-            localStorage.removeItem("nickname");
-            localStorage.removeItem("profileImageUrl");
             useAuthStore.persist.clearStorage();
             navigate("/login");
           })

--- a/src/pages/profile/ProfileEdit.tsx
+++ b/src/pages/profile/ProfileEdit.tsx
@@ -7,6 +7,7 @@ import styled from "@emotion/styled";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import postMyProfileImage from "@/apis/profile/postMyProfileImage.ts";
+import type { MyProfileData } from "@/apis/profile/type.ts";
 import updateMyProfile from "@/apis/profile/updateMyProfile.ts";
 import getNicknameValid from "@/apis/register/getNicknameValid.ts";
 import AlertText from "@/components/common/AlertText";
@@ -38,7 +39,7 @@ const ProfileEdit = () => {
   });
   const queryClient = useQueryClient();
 
-  // const data = queryClient.getQueryData(["myProfileData"]);
+  const data = queryClient.getQueryData<MyProfileData>(["myProfileData"]);
 
   const checkNicknameDuplicated = (nickname: string) => {
     if (nickname.length === 0) {
@@ -145,7 +146,7 @@ const ProfileEdit = () => {
           <Avatar
             width={80}
             height={80}
-            imgUrl={imgSrc}
+            imgUrl={data?.profileImageUrl ?? imgSrc}
           />
           <Spacing size={20} />
           <label htmlFor={"profile-image-upload"}>
@@ -164,6 +165,7 @@ const ProfileEdit = () => {
               <RegisterInput
                 width={240}
                 placeholder={"닉네임 (10자 제한)"}
+                defaultValue={data?.nickname}
                 {...userInfoForm.register("nickname")}
               />
               <NormalButton
@@ -220,6 +222,7 @@ const ProfileEdit = () => {
                     isDarkMode={isDarkMode}
                     itemList={InterestList}
                     maxCount={3}
+                    defaultSelectedList={data?.interests}
                     onValueChange={field.onChange}
                   />
                 )}

--- a/src/pages/profile/ProfileEdit.tsx
+++ b/src/pages/profile/ProfileEdit.tsx
@@ -70,8 +70,6 @@ const ProfileEdit = () => {
       formData.append("profileImage", file);
       postMyProfileImage(formData)
         .then(() => {
-          imgSrc && localStorage.setItem("profileImageUrl", imgSrc);
-
           showToast({
             message: "프로필 이미지가 수정되었습니다.",
             type: "success",

--- a/src/pages/profile/ProfileEdit.tsx
+++ b/src/pages/profile/ProfileEdit.tsx
@@ -69,13 +69,14 @@ const ProfileEdit = () => {
       const formData = new FormData();
       formData.append("profileImage", file);
       postMyProfileImage(formData)
-        .then(() => {
+        .then(async () => {
           showToast({
             message: "프로필 이미지가 수정되었습니다.",
             type: "success",
             isDarkMode,
           });
-          queryClient.invalidateQueries({ queryKey: ["myProfileData"] });
+          await queryClient.invalidateQueries({ queryKey: ["myProfileData"] });
+          await queryClient.refetchQueries({ queryKey: ["myProfileData"] });
         })
         .catch(() => {
           showToast({
@@ -102,13 +103,14 @@ const ProfileEdit = () => {
       interests: data.interest,
     };
     updateMyProfile(updateData)
-      .then(() => {
+      .then(async () => {
         showToast({
           message: "프로필이 수정되었습니다.",
           type: "success",
           isDarkMode,
         });
-        queryClient.invalidateQueries({ queryKey: ["myProfileData"] });
+        await queryClient.invalidateQueries({ queryKey: ["myProfileData"] });
+        await queryClient.refetchQueries({ queryKey: ["myProfileData"] });
         navigate("/profile");
       })
       .catch(() => {

--- a/src/pages/register/RegisterCompany.tsx
+++ b/src/pages/register/RegisterCompany.tsx
@@ -29,7 +29,6 @@ const RegisterCompany = () => {
   const navigate = useNavigate();
   const { showToast } = useToast();
   const isDarkMode = useThemeStore((state) => state.isDarkMode);
-
   const userInfo: UserInfoType = useLocation().state;
   const [isCodeSame, setIsCodeSame] = useState<null | boolean>(null);
   const [codeChecked, setCodeChecked] = useState<null | boolean>(null);

--- a/src/pages/register/RegisterUser.tsx
+++ b/src/pages/register/RegisterUser.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { MdWbSunny } from "react-icons/md";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import type { UserInfoStateType } from "@/schemas/userInfo";
 import { UserInfoSchema } from "@/schemas/userInfo";
 import styled from "@emotion/styled";
@@ -16,12 +16,13 @@ import Spacing from "@/components/common/Spacing";
 import useToast from "@/hooks/useToast";
 import { palette } from "@/styles/palette";
 import { typo } from "@/styles/typo";
+import useAuthStore from "@/store/AuthStore.tsx";
 import useThemeStore from "@/store/ThemeStore";
 import { InterestList } from "@/constants/index.ts";
 
 const RegisterUser = () => {
   const navigate = useNavigate();
-  const userId = useLocation().state.userId;
+  const userId = useAuthStore((state) => state.userId);
 
   const [doubleChecked, setDoubleChecked] = useState<null | boolean>(false);
   const [nicknameDuplicated, setNicknameDuplicated] = useState<null | boolean>(null);

--- a/src/store/AuthStore.tsx
+++ b/src/store/AuthStore.tsx
@@ -10,8 +10,10 @@ type Tokens = {
 type AuthState = {
   provider: Provider;
   authTokens?: Tokens;
+  userId: number;
   setProvider: (provider: Provider) => void;
   setAuthTokens: (authTokens: Tokens) => void;
+  setUserId: (userId: number) => void;
 };
 
 const useAuthStore = create(
@@ -19,11 +21,13 @@ const useAuthStore = create(
     (set) => ({
       authTokens: undefined,
       provider: "KAKAO",
+      userId: 0,
       setProvider: (provider: Provider) => set(() => ({ provider })),
       setAuthTokens: (authTokens: Tokens) =>
         set(() => ({
           authTokens,
         })),
+      setUserId: (userId: number) => set(() => ({ userId })),
     }),
     {
       name: "auth-store",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -56,7 +56,10 @@
       ],
       "@/store/*": [
         "src/store/*"
-      ]
+      ],
+      "@/libs/*": [
+        "src/libs/*"
+      ],
     }
   },
   "include": [


### PR DESCRIPTION
## 이슈번호

<!-- - close 뒤에 이슈 달아주기 -->
close: #

## 작업 내용 설명

<!-- 스크린샷 및 작업내용을 적어주세요 -->
- 네이버 로그인 버튼을 숨김 처리 하였습니다. (네아로 승인 문제로 기능 잠정 중단)
- authStore에 userId를 추가하였습니다. localStorage에서 별도의 데이터로 관리되지 않습니다.
- localStorage에서 별도의 데이터로 관리되던 profileImage, nickname을 제거하였습니다.
- accessToken을 `jwt`라는 별도의 localStorage데이터에서 꺼내왔으나, authStore를 활용하도록 변경하였습니다.
- 일부 캐시 데이터 만료 후 refetch 메소드를 호출하지 않아 발생하던 문제를 수정하였습니다.
- MultiSelector에 `defaultSelectedList` Prop을 추가하였습니다.
- 유저 프로필, 회사 정보 수정 페이지에 이제 기존 데이터가 삽입되도록 변경하였습니다.
- axios가 기본적으로 fetch 단에서 에러를 감지하면 reject된 Promise를 반환하기 때문에 불필요한 Error를 throw하지 않도록 getMyProfileData 함수에서 해당 로직을 제거했습니다.
- 전역으로 사용되는 queryClient의 데이터 fetching 재시도 횟수를 3(기본값) -> 1로 설정하였습니다.
- queryOptions의 공유를 위한 디렉토리와 첫 옵션을 생성했습니다!(`getMyProfileDataOptions`)
- 프로필 페이지에서 캐시된 데이터를 보여주지만, 새로고침시 이 데이터를 불러올 수 없어 발생하던 문제를 수정했습니다!
- axios의 미들웨어를 비활성화시켰습니다! 물론 기존의 기능들은 보존하였고, 추후 필요에 의해 재활성화될 수 있습니다.

## 리뷰어에게 한마디

<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->
