### PR TITLE
💄 Style: Toast Library 교체

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "react-icons": "^4.11.0",
         "react-router-dom": "^6.16.0",
         "react-spinners": "^0.13.8",
-        "react-toastify": "^9.1.3",
+        "sonner": "^1.3.1",
         "zod": "^3.22.4",
         "zustand": "^4.4.4",
         "zustand-persist": "^0.4.0"
@@ -1261,9 +1261,9 @@
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.4.0.tgz",
-      "integrity": "sha512-PQ6+lWNrvh74GvFTHT4gCutFipDmtu8D1tNNawKe+/SyL6XFgeuMYgZIpKQgkTSezVDogC7EGQTJBFnewF9pOg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.4.1.tgz",
+      "integrity": "sha512-S51XnILdhNt0ZA6bPnbxpqKPI5LatbGY9RQjA2TmATrjSPE3aWndJsLIrutI6aS9K+YFwy5+HLDKVRFYQfmKAw==",
       "dependencies": {
         "@firebase/component": "0.5.6",
         "@firebase/firestore-types": "2.4.0",
@@ -1272,7 +1272,7 @@
         "@firebase/webchannel-wrapper": "0.5.1",
         "@grpc/grpc-js": "^1.3.2",
         "@grpc/proto-loader": "^0.6.0",
-        "node-fetch": "2.6.1",
+        "node-fetch": "2.6.7",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1293,22 +1293,33 @@
       }
     },
     "node_modules/@firebase/firestore/node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.6.15",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.15.tgz",
-      "integrity": "sha512-b7RpLwFXi0N+HgkfK8cmkarSOoBeSrc1jNdadkCacQt+vIePkKM3E9EJXF4roWSa8GwTruodpBsvH+lK9iCAKQ==",
+      "version": "0.6.16",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.16.tgz",
+      "integrity": "sha512-KDPjLKSjtR/zEH06YXXbdWTi8gzbKHGRzL/+ibZQA/1MLq0IilfM+1V1Fh8bADsMCUkxkqoc1yiA4SUbH5ajJA==",
       "dependencies": {
         "@firebase/component": "0.5.6",
         "@firebase/functions-types": "0.4.0",
         "@firebase/messaging-types": "0.5.0",
-        "node-fetch": "2.6.1",
+        "node-fetch": "2.6.7",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1322,11 +1333,22 @@
       "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ=="
     },
     "node_modules/@firebase/functions/node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@firebase/installations": {
@@ -1448,14 +1470,14 @@
       "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
     },
     "node_modules/@firebase/storage": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.7.0.tgz",
-      "integrity": "sha512-ebDFKJbM5HOxVtZV+RhVEBVtlWHK+Z5L3kA5uDBA2jMYcn+8NV/crozJnEE+iRsGEco6dLK5JS+Er4qtKLpH5A==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.7.1.tgz",
+      "integrity": "sha512-T7uH6lAgNs/Zq8V3ElvR3ypTQSGWon/R7WRM2I5Td/d0PTsNIIHSAGB6q4Au8mQEOz3HDTfjNQ9LuQ07R6S2ug==",
       "dependencies": {
         "@firebase/component": "0.5.6",
         "@firebase/storage-types": "0.5.0",
         "@firebase/util": "1.3.0",
-        "node-fetch": "2.6.1",
+        "node-fetch": "2.6.7",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1473,11 +1495,22 @@
       }
     },
     "node_modules/@firebase/storage/node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@firebase/util": {
@@ -1494,9 +1527,9 @@
       "integrity": "sha512-dZMzN0uAjwJXWYYAcnxIwXqRTZw3o14hGe7O6uhwjD1ZQWPVYA5lASgnNskEBra0knVBsOXB4KXg+HnlKewN/A=="
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.11",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.11.tgz",
-      "integrity": "sha512-QDhMfbTROOXUhLHMroow8f3EHiCKUOh6UwxMP5S3EuXMnWMNSVIhatGZRwkpg9OUTYdZPsDUVH3cOAkWhGFUJw==",
+      "version": "1.9.14",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.14.tgz",
+      "integrity": "sha512-nOpuzZ2G3IuMFN+UPPpKrC6NsLmWsTqSsm66IRfnBt1D4pwTqE27lmbpcPM+l2Ua4gE7PfjRHI6uedAy7hoXUw==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
@@ -1528,9 +1561,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/@grpc/grpc-js/node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -3887,11 +3920,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -4298,14 +4331,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -5885,9 +5910,9 @@
       }
     },
     "node_modules/firebase": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.10.0.tgz",
-      "integrity": "sha512-GCABTbJdo88QgzX5OH/vsfKBWvTRbLUylGlYXtO7uYo1VErfGd2BWW9ATlJP5Gxx+ClDfyvVTvcs2rcNWn3uUA==",
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.10.1.tgz",
+      "integrity": "sha512-84z/zqF8Y5IpUYN8nREZ/bxbGtF5WJDOBy4y0hAxRzGpB5+2tw9PQgtTnUzk6MQiVEf/WOniMUL3pCVXKsxALw==",
       "dependencies": {
         "@firebase/analytics": "0.6.18",
         "@firebase/app": "0.6.30",
@@ -5895,14 +5920,14 @@
         "@firebase/app-types": "0.6.3",
         "@firebase/auth": "0.16.8",
         "@firebase/database": "0.11.0",
-        "@firebase/firestore": "2.4.0",
-        "@firebase/functions": "0.6.15",
+        "@firebase/firestore": "2.4.1",
+        "@firebase/functions": "0.6.16",
         "@firebase/installations": "0.4.32",
         "@firebase/messaging": "0.8.0",
         "@firebase/performance": "0.4.18",
         "@firebase/polyfill": "0.3.36",
         "@firebase/remote-config": "0.1.43",
-        "@firebase/storage": "0.7.0",
+        "@firebase/storage": "0.7.1",
         "@firebase/util": "1.3.0"
       },
       "engines": {
@@ -5930,9 +5955,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -8372,18 +8397,6 @@
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-toastify": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
-      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
-      "dependencies": {
-        "clsx": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -8966,6 +8979,15 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/sonner": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.3.1.tgz",
+      "integrity": "sha512-+rOAO56b2eI3q5BtgljERSn2umRk63KFIvgb2ohbZ5X+Eb5u+a/7/0ZgswYqgBMg8dyl7n6OXd9KasA8QF9ToA==",
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -9287,8 +9309,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
@@ -9546,9 +9567,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -9645,8 +9666,7 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -9678,7 +9698,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-icons": "^4.11.0",
     "react-router-dom": "^6.16.0",
     "react-spinners": "^0.13.8",
-    "react-toastify": "^9.1.3",
+    "sonner": "^1.3.1",
     "zod": "^3.22.4",
     "zustand": "^4.4.4",
     "zustand-persist": "^0.4.0"

--- a/src/components/common/AppHeader/index.tsx
+++ b/src/components/common/AppHeader/index.tsx
@@ -80,7 +80,6 @@ const AppHeader = ({ isAuth, isDarkMode, height, toggleDarkMode }: AppHeaderProp
     showToast({
       message: "프로필 정보를 불러오는데 실패했습니다.",
       type: "error",
-      isDarkMode,
     });
     useAuthStore.persist.clearStorage();
     navigate("/login");

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,11 +1,21 @@
 import { Outlet } from "react-router-dom";
 import styled from "@emotion/styled";
+import { Toaster } from "sonner";
 import Modal from "@/components/common/Modal";
 import { theme } from "@/styles/theme";
+import useThemeStore from "@/store/ThemeStore.tsx";
 
 const Layout = () => {
+  const isDarkMode = useThemeStore((state) => state.isDarkMode);
+
   return (
     <MainContainer>
+      <Toaster
+        duration={2000}
+        position={"top-center"}
+        theme={isDarkMode ? "dark" : "light"}
+        richColors
+      />
       <Modal />
       <Outlet />
     </MainContainer>

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,6 +1,4 @@
 import { Outlet } from "react-router-dom";
-import { ToastContainer } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
 import styled from "@emotion/styled";
 import Modal from "@/components/common/Modal";
 import { theme } from "@/styles/theme";
@@ -10,7 +8,6 @@ const Layout = () => {
     <MainContainer>
       <Modal />
       <Outlet />
-      <ToastContainer />
     </MainContainer>
   );
 };

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -1,22 +1,30 @@
 import type { ReactNode } from "react";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 
 type ToastType = "success" | "error" | "info" | "warning";
 
 type ToastProps = {
   message: string | ReactNode;
-  type: ToastType;
-  isDarkMode: boolean;
+  type?: ToastType;
 };
 
 export const useToast = () => {
-  const showToast = ({ message, type, isDarkMode }: ToastProps) => {
-    toast(message, {
-      position: "top-center",
-      draggable: true,
-      theme: isDarkMode ? "dark" : "light",
-      type,
-    });
+  const showToast = ({ message, type }: ToastProps) => {
+    switch (type) {
+      case "success":
+        toast.success(message);
+        return;
+      case "error":
+        toast.error(message);
+        return;
+      case "info":
+        toast.info(message);
+        return;
+      case "warning":
+        toast.warning(message);
+        return;
+    }
+    toast(message);
   };
 
   return { showToast };

--- a/src/pages/admin/AdminLogin.tsx
+++ b/src/pages/admin/AdminLogin.tsx
@@ -26,7 +26,6 @@ const AdminLogin = () => {
       showToast({
         message: "올바른 id, password를 입력해주세요!",
         type: "warning",
-        isDarkMode: false,
       });
     },
   });

--- a/src/pages/chatting/Chatting.tsx
+++ b/src/pages/chatting/Chatting.tsx
@@ -121,7 +121,6 @@ const Chatting = () => {
       showToast({
         message: "삭제된 채팅방입니다😭. 홈으로 이동합니다!",
         type: "warning",
-        isDarkMode: false,
       });
       navigateHome();
     }
@@ -176,7 +175,6 @@ const Chatting = () => {
       showToast({
         message: "삭제된 채팅방입니다😭. 홈으로 이동합니다!",
         type: "warning",
-        isDarkMode: false,
       });
       navigateHome();
     }

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -24,7 +24,6 @@ const Home = () => {
       showToast({
         message: "로그인이 필요한 서비스입니다!",
         type: "warning",
-        isDarkMode,
       });
       navigate("/login");
     }
@@ -73,7 +72,6 @@ const Home = () => {
             showToast({
               message: "아직 준비중인 기능입니다!",
               type: "info",
-              isDarkMode,
             });
           }}
         />

--- a/src/pages/home/components/Card.tsx
+++ b/src/pages/home/components/Card.tsx
@@ -172,6 +172,7 @@ const Card = ({ isDarkMode }: CardProps) => {
                   display: "flex",
                   justifyContent: "center",
                   textAlign: "center",
+                  color: isDarkMode ? `${palette.DARK_WHITE}` : `${palette.DARK_BLUE}`,
                 }}
               >
                 {formatTime(time)}
@@ -193,6 +194,7 @@ const Card = ({ isDarkMode }: CardProps) => {
                   display: "flex",
                   justifyContent: "center",
                   textAlign: "center",
+                  color: isDarkMode ? `${palette.DARK_WHITE}` : `${palette.DARK_BLUE}`,
                 }}
               >
                 {"매칭 중"}&nbsp;&nbsp;&nbsp;

--- a/src/pages/loginPending/LoginPending.tsx
+++ b/src/pages/loginPending/LoginPending.tsx
@@ -49,7 +49,6 @@ const LoginPending = () => {
         showToast({
           message: "로그인에 실패했습니다.",
           type: "error",
-          isDarkMode: false,
         });
         navigate("/login");
       });

--- a/src/pages/profile/ProfileCompanyEdit.tsx
+++ b/src/pages/profile/ProfileCompanyEdit.tsx
@@ -47,24 +47,24 @@ const ProfileCompanyEdit = () => {
 
   const handleVerifyEmail = async (email: string) => {
     if (!email) {
-      showToast({ message: "이메일을 입력해주세요! ", type: "warning", isDarkMode });
+      showToast({ message: "이메일을 입력해주세요! ", type: "warning" });
       return;
     }
     if (!userId) {
-      showToast({ message: "로그인이 필요합니다! ", type: "warning", isDarkMode });
+      showToast({ message: "로그인이 필요합니다! ", type: "warning" });
       return;
     }
-    showToast({ message: "인증코드가 전송되었습니다! ", type: "success", isDarkMode });
+    showToast({ message: "인증코드가 전송되었습니다! ", type: "success" });
     return await sendEmailValidCode(email, userId.toString());
   };
 
   const handleVerifyCode = async (code: string) => {
     if (!code) {
-      showToast({ message: "인증코드를 입력해주세요! ", type: "warning", isDarkMode });
+      showToast({ message: "인증코드를 입력해주세요! ", type: "warning" });
       return;
     }
     if (!userId) {
-      showToast({ message: "로그인이 필요합니다! ", type: "warning", isDarkMode });
+      showToast({ message: "로그인이 필요합니다! ", type: "warning" });
       return;
     }
     setCodeChecked(true);
@@ -85,15 +85,15 @@ const ProfileCompanyEdit = () => {
 
   const handleChangeCompanyInfo = (data: CompanyInfoStateType) => {
     if (!userId) {
-      showToast({ message: "로그인이 필요합니다! ", type: "warning", isDarkMode });
+      showToast({ message: "로그인이 필요합니다! ", type: "warning" });
       return;
     }
     if (!codeChecked) {
-      showToast({ message: "인증코드가 확인되지 않았습니다! ", type: "warning", isDarkMode });
+      showToast({ message: "인증코드가 확인되지 않았습니다! ", type: "warning" });
       return;
     }
     if (!isCodeSame) {
-      showToast({ message: "인증코드가 일치하지 않습니다! ", type: "warning", isDarkMode });
+      showToast({ message: "인증코드가 일치하지 않습니다! ", type: "warning" });
       return;
     }
     const formData = new FormData();
@@ -107,7 +107,6 @@ const ProfileCompanyEdit = () => {
         showToast({
           message: "회사 정보 변경 완료!",
           type: "success",
-          isDarkMode: false,
         });
         navigate("/profile");
       })
@@ -115,7 +114,6 @@ const ProfileCompanyEdit = () => {
         showToast({
           message: "회사 정보 변경에 실패했습니다.",
           type: "error",
-          isDarkMode: false,
         });
       });
   };

--- a/src/pages/profile/ProfileDefault.tsx
+++ b/src/pages/profile/ProfileDefault.tsx
@@ -43,7 +43,6 @@ const ProfileDefault = () => {
     showToast({
       message: "프로필 정보를 불러오는데 실패했습니다.",
       type: "error",
-      isDarkMode,
     });
     useAuthStore.persist.clearStorage();
     navigate("/login");
@@ -220,7 +219,6 @@ const ProfileDefault = () => {
               showToast({
                 message: "아직 준비중인 기능입니다!",
                 type: "info",
-                isDarkMode,
               });
             }}
           />

--- a/src/pages/profile/ProfileEdit.tsx
+++ b/src/pages/profile/ProfileEdit.tsx
@@ -46,7 +46,6 @@ const ProfileEdit = () => {
       showToast({
         message: "닉네임을 입력하세요!",
         type: "warning",
-        isDarkMode,
       });
       return;
     }
@@ -74,7 +73,6 @@ const ProfileEdit = () => {
           showToast({
             message: "프로필 이미지가 수정되었습니다.",
             type: "success",
-            isDarkMode,
           });
           await queryClient.refetchQueries({ queryKey: ["myProfileData"] });
         })
@@ -82,7 +80,6 @@ const ProfileEdit = () => {
           showToast({
             message: "프로필 이미지 수정에 실패했습니다.",
             type: "error",
-            isDarkMode,
           });
         });
     }
@@ -93,7 +90,6 @@ const ProfileEdit = () => {
       showToast({
         message: "닉네임 중복검사를 해주세요!",
         type: "warning",
-        isDarkMode,
       });
       return;
     }
@@ -107,7 +103,6 @@ const ProfileEdit = () => {
         showToast({
           message: "프로필이 수정되었습니다.",
           type: "success",
-          isDarkMode,
         });
         await queryClient.refetchQueries({ queryKey: ["myProfileData"] });
         navigate("/profile");
@@ -116,7 +111,6 @@ const ProfileEdit = () => {
         showToast({
           message: "프로필 수정에 실패했습니다.",
           type: "error",
-          isDarkMode,
         });
       });
   };

--- a/src/pages/profile/ProfileHelpDesk.tsx
+++ b/src/pages/profile/ProfileHelpDesk.tsx
@@ -32,11 +32,11 @@ const ProfileHelpDesk = () => {
     }
     postMyInquiry(inputRef.current.value, textareaRef.current.value)
       .then(() => {
-        showToast({ message: "불편사항이 접수되었습니다.", type: "success", isDarkMode });
+        showToast({ message: "불편사항이 접수되었습니다.", type: "success" });
         navigate("/profile");
       })
       .catch(() => {
-        showToast({ message: "불편사항 접수에 실패했습니다.", type: "error", isDarkMode });
+        showToast({ message: "불편사항 접수에 실패했습니다.", type: "error" });
       });
   };
   return (

--- a/src/pages/register/RegisterCompany.tsx
+++ b/src/pages/register/RegisterCompany.tsx
@@ -56,14 +56,12 @@ const RegisterCompany = () => {
       showToast({
         message: "이메일을 입력해주세요.",
         type: "warning",
-        isDarkMode,
       });
       return;
     }
     showToast({
       message: "메일로 인증코드가 전송되었습니다.",
       type: "info",
-      isDarkMode,
     });
     return await sendEmailValidCode(email, userId.toString());
   };
@@ -79,7 +77,6 @@ const RegisterCompany = () => {
       showToast({
         message: "인증코드를 입력해주세요.",
         type: "warning",
-        isDarkMode,
       });
       return;
     }
@@ -97,14 +94,12 @@ const RegisterCompany = () => {
       showToast({
         message: "인증코드가 확인되지 않았습니다. ",
         type: "warning",
-        isDarkMode,
       });
       return false;
     } else if (!isCodeSame) {
       showToast({
         message: "인증코드가 일치하지 않습니다. ",
         type: "warning",
-        isDarkMode,
       });
       return false;
     }
@@ -129,14 +124,12 @@ const RegisterCompany = () => {
       showToast({
         message: "회원 가입 완료! 다시 로그인 해주세요!",
         type: "success",
-        isDarkMode: false,
       });
       navigate("/login");
     } catch (error) {
       showToast({
         message: "회원 가입에 실패했습니다.",
         type: "error",
-        isDarkMode: false,
       });
     }
   };

--- a/src/pages/register/RegisterUser.tsx
+++ b/src/pages/register/RegisterUser.tsx
@@ -58,21 +58,18 @@ const RegisterUser = () => {
       showToast({
         message: "닉네임을 입력하세요!",
         type: "warning",
-        isDarkMode,
       });
       return false;
     } else if (!doubleChecked) {
       showToast({
         message: "중복검사를 해주세요!",
         type: "warning",
-        isDarkMode,
       });
       return false;
     } else if (nicknameDuplicated) {
       showToast({
         message: "사용할 수 없는 닉네임입니다.",
         type: "warning",
-        isDarkMode,
       });
       return false;
     } else {


### PR DESCRIPTION
## 이슈번호

<!-- - close 뒤에 이슈 달아주기 -->
close #283 

## 작업 내용 설명
![Jan-28-2024 00-03-44](https://github.com/coffee-meet/frontend/assets/69716992/0b6c06a0-3538-431a-b981-0abd17329eb4)
![Jan-28-2024 00-03-50](https://github.com/coffee-meet/frontend/assets/69716992/39941d8a-3ca6-46e8-b0a1-736b50419dc0)

- Toast 라이브러리를 교체했습니다 (react-toastify -> sonner)
- Toast 노출 시간을 조금 줄였습니다 (약 6초? -> 2초)
- 매칭 타이머 시간과 매칭중 Label의 색상을 다크모드에 대응되도록 인라인 스타일을 추가했습니다


## 리뷰어에게 한마디

<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->
